### PR TITLE
Celennia Memorial Library - Caldera NPC module overrides

### DIFF
--- a/modules/custom/lua/caldera_npc_module/Andreine.lua
+++ b/modules/custom/lua/caldera_npc_module/Andreine.lua
@@ -1,0 +1,2697 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Andreine
+-- !pos -91 -2 -91 284
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
+require("scripts/globals/shop")
+require("modules/module_utils")
+-----------------------------------
+
+local m = Module:new("Andreine")
+
+local npcToReplaceName = "Andreine"
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	local job = player:getMainJob()
+	local level = player:getMainLvl()
+	
+	if (job == xi.job.WAR) then
+		local stock_WAR = {}
+		player:PrintToPlayer(string.format("Andreine : I've got gear to get your Warrior's arsenal started!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then	
+			stock_WAR =
+				{
+					16610,	5000,		-- (Sword) Wax Sword +1
+					16716,	5000,		-- (Great Axe) Butterfly Axe +1
+					16646,	5000,		-- (Axe) Bronze Axe +1
+					17175,	5000,		-- (Archery) Shortbow +1
+					17228,	5000,		-- (Marksmanship) Light Crossbow +1
+					17290,	5000,		-- (Throwing) Coarse Boomerang
+					4219,	200,		-- (Ammunition) Stone Arrow Quiver
+					4227,	200,		-- (Ammunition) Bronze Bolt Quiver
+					12695,	2000,		-- (Gloves) Bronze Mittens +1
+					12823,  2000,       -- (Legs) Bronze Subligar +1
+					12951,	2000,		-- (Feet) Bronze Leggings +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13226,	2000,		-- (Waist) Blood Stone +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_WAR =
+				{
+					16812,  15000,      -- (Sword) War Sword
+					16718,	15000,		-- (Great Axe) Heavy Axe +1
+					16664,	15000,		-- (Axe) War Pick +1
+					17179,	15000,		-- (Archery) Composite Bow +1
+					17229,	15000,		-- (Marksmanship) Zamburak +1
+					4222,	2000,		-- (Ammunition) Horn Arrow Quiver
+					4228,	2000,		-- (Ammunition) Mythril Bolt Quiver
+					12533,  10000,      -- (Head) Silver Mask +1
+					12666,  10000,      -- (Body) Silver Mail +1
+					12772,  10000,      -- (Hands) Silver Mittens +1
+					12894,  10000,      -- (Legs) Silver Hose +1
+					13029,  10000,      -- (Feet) Silver Greaves +1
+					13070,	5000,		-- (Neck) Wolf Gorget +1
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13519,	5000,		-- (Ring) Mythril Ring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_WAR =
+				{
+					16828,  25000,      -- (Sword) Bastard Sword +1
+					16731,	25000,		-- (Great Axe) Colossal Axe +1
+					16682,	25000,		-- (Axe) Darksteel Pick +1
+					17189,	25000,		-- (Archery) Rapid Bow +1
+					17227,	25000,		-- (Marksmanship) Heavy Crossbow +1
+					4224,	5000,		-- (Ammunition) Demon Arrow Quiver
+					4229,	5000,		-- (Ammunition) Darksteel Bolt Quiver
+					15225,	50000,		-- (Head) Fighter's Mask +1
+					14473,	50000,		-- (Body) Fighter's Lorica +1
+					14890,	50000,		-- (Hands) Fighter's Mufflers +1
+					15561,	50000,		-- (Legs) Fighter's Cuisses +1
+					15352,	50000,		-- (Feet) Fighter's Calligae +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13403,	10000,		-- (Earring) Assault Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_WAR =
+				{
+					18512,	40000,		-- (Great Axe) Dolor Bhuj +1
+					16662,	40000,		-- (Axe) Doom Tabar +1
+					18701,	40000,		-- (Archery) Cerberus Bow +1
+					19266,	40000,		-- (Marksmanship) Darkwing +1
+					5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
+					5821,	7500,		-- (Ammunition) Fusion Bolt Quiver
+					11064,	50000,		-- (Head) Ravager's Mask +2
+					11084,	50000,		-- (Body) Ravager's Lorica +2
+					11104,	50000,		-- (Hands) Ravager's Mufflers +2
+					11124,	50000,		-- (Legs) Ravager's Cuisses +2
+					11144,	50000,		-- (Feet) Ravager's Calligae +2
+					11591,  50000,		-- (Neck) Ravager's Gorget
+					11703,  50000,		-- (Earring) Ravager's Earring
+					19253,  50000,		-- (Ammunition) Ravager's Orb
+					10650,	50000,		-- (Head) Warrior's Mask +2
+					10670,	50000,		-- (Body) Warrior's Lorica +2
+					10690,	50000,		-- (Hands) Warrior's Mufflers +2
+					10710,	50000,		-- (Legs) Warrior's Cuisses +2
+					10730,	50000,		-- (Feet) Warrior's Calligae +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11678,	30000,		-- (Earring) Flame Earring
+					14630,	30000,		-- (Ring) Flame Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_WAR =
+				{
+					18916,  300000,		-- (Sword) Heimdall's Doom
+					20879,	100000,		-- (Great Axe) Nohkux Axe +1
+					20832,	65000,		-- (Axe) Aalak' Axe +1
+					19785,	100000,		-- (Archery) Lanner Bow +1
+					19266,	40000,		-- (Marksmanship) Darkwing +1
+					6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
+					6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
+					10442,  300000,		-- (Head) Laeradr Helm
+					10280,  300000,		-- (Body) Laeradr Breastplate
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11064,	50000,		-- (Head) Ravager's Mask +2
+					11084,	50000,		-- (Body) Ravager's Lorica +2
+					11104,	50000,		-- (Hands) Ravager's Mufflers +2
+					11124,	50000,		-- (Legs) Ravager's Cuisses +2
+					11144,	50000,		-- (Feet) Ravager's Calligae +2
+					11591,  50000,		-- (Neck) Ravager's Gorget
+					11703,  50000,		-- (Earring) Ravager's Earring
+					19253,  50000,		-- (Ammunition) Ravager's Orb
+					10650,	50000,		-- (Head) Warrior's Mask +2
+					10670,	50000,		-- (Body) Warrior's Lorica +2
+					10690,	50000,		-- (Hands) Warrior's Mufflers +2
+					10710,	50000,		-- (Legs) Warrior's Cuisses +2
+					10730,	50000,		-- (Feet) Warrior's Calligae +2
+					-- 25417,	50000,		-- (Neck) Warrior's Bead Necklace
+					10831,	50000,		-- (Waist) Paewr Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_WAR)
+	elseif (job == xi.job.MNK) then
+		local stock_MNK = {}
+		player:PrintToPlayer(string.format("Andreine : Ah, the supreme focus of a Monk! I wish I could focus like you..."),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_MNK =
+				{
+					20533,	5000,		-- (Hand-to-Hand) Worm Feelers +1
+					16690,	5000,		-- (Hand-to-Hand) Cesti +1
+					17296,	1,			-- (Throwing) Pebble
+					12695,	2000,		-- (Gloves) Bronze Mittens +1
+					12823,  2000,       -- (Legs) Bronze Subligar +1
+					12951,	2000,		-- (Feet) Bronze Leggings +1
+					13060,	2000,		-- (Neck) Feather Collar +1
+					13184,  5000,       -- (Waist) White Belt
+					13201,  12000,       -- (Waist) Purple Belt
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_MNK =
+				{
+					16445,	15000,		-- (Hand-to-Hand) Claws +1
+					17298,	20,			-- (Ammunition) Tathlum
+					12539,  10000,      -- (Head) Soil Hachimaki +1
+					12671,  10000,      -- (Body) Soil Gi +1
+					12781,  10000,      -- (Hands) Soil Tekko +1
+					12905,  10000,      -- (Legs) Soil Sitabaki +1
+					13035,  10000,      -- (Feet) Soil Kyahan +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13202,	30000,		-- (Waist) Brown Belt
+					13575,	5000,		-- (Back) Ram Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13519,	5000,		-- (Ring) Mythril Ring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_MNK =
+				{
+					18751,  25000,      -- (Hand-to-Hand) Black Adargas +1
+					17299,	50,			-- (Ammunition) Astragalos
+					15226,	50000,		-- (Head) Temple Crown +1
+					14474,	50000,		-- (Body) Temple Cyclas +1
+					14891,	50000,		-- (Hands) Temple Gloves +1
+					15562,	50000,		-- (Legs) Temple Hose +1
+					15353,	50000,		-- (Feet) Temple Gaiters +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					13186,  75000,      -- (Waist) Black Belt
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13369,	10000,		-- (Earring) Spike Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_MNK =
+				{
+					18775,	40000,		-- (Hand-to-Hand) Savate Fists +1
+					19249,	20000,		-- (Ammunition) Thew Bomblet
+					11065,	50000,		-- (Head) Tantra Crown +2
+					11085,	50000,		-- (Body) Tantra Cyclas +2
+					11105,	50000,		-- (Hands) Tantra Gloves +2
+					11125,	50000,		-- (Legs) Tantra Hose +2
+					11145,	50000,		-- (Feet) Tantra Gaiters +2
+					11592,  50000,		-- (Neck) Tantra Necklace
+					11704,  50000,		-- (Earring) Tantra Earring
+					19254,  50000,		-- (Ammunition) Tantra Tathlum
+					10651,	50000,		-- (Head) Melee Crown +2
+					10671,	50000,		-- (Body) Melee Cyclas +2
+					10691,	50000,		-- (Hands) Melee Gloves +2
+					10711,	50000,		-- (Legs) Melee Hose +2
+					10731,	50000,		-- (Feet) Melee Gaiters +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					13186,  75000,      -- (Waist) Black Belt
+					11678,	30000,		-- (Earring) Flame Earring
+					14630,	30000,		-- (Ring) Flame Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_MNK =
+				{
+					20552,	100000,		-- (Hand-to-Hand) Akua Sainti +1
+					19249,	20000,		-- (Ammunition) Thew Bomblet
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11065,	50000,		-- (Head) Tantra Crown +2
+					11085,	50000,		-- (Body) Tantra Cyclas +2
+					11105,	50000,		-- (Hands) Tantra Gloves +2
+					11125,	50000,		-- (Legs) Tantra Hose +2
+					11145,	50000,		-- (Feet) Tantra Gaiters +2
+					11592,  50000,		-- (Neck) Tantra Necklace
+					11704,  50000,		-- (Earring) Tantra Earring
+					19254,  50000,		-- (Ammunition) Tantra Tathlum
+					10651,	50000,		-- (Head) Melee Crown +2
+					10671,	50000,		-- (Body) Melee Cyclas +2
+					10691,	50000,		-- (Hands) Melee Gloves +2
+					10711,	50000,		-- (Legs) Melee Hose +2
+					10731,	50000,		-- (Feet) Melee Gaiters +2
+					-- 25423,	50000,		-- (Neck) Monk's Nodowa
+					13186,  75000,      -- (Waist) Black Belt
+					10831,	50000,		-- (Waist) Paewr Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_MNK)
+	elseif (job == xi.job.WHM) then
+		local stock_WHM = {}
+		player:PrintToPlayer(string.format("Andreine : Hopefully this gear will make leveling White Mage just a little less painful!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_WHM =
+				{
+					17087,	5000,		-- (Club) Maple Wand +1
+					17137,	5000,		-- (Club) Ash Club +1
+					17144,	5000,		-- (Club) Bronze Hammer +1
+					17123,	5000,		-- (Staff) Ash Staff +1
+					17122,	5000,		-- (Staff) Ash Pole +1
+					12744,	2000,		-- (Gloves) Cuffs +1
+					12897,  2000,       -- (Legs) Slops +1
+					12983,	2000,		-- (Feet) Ash Clogs +1
+					13093,	2000,		-- (Neck) Justice Badge
+					13190,	2000,		-- (Waist) Heko Obi +1
+					13605,	2000,		-- (Back) Cape +1
+					14694,	2000,		-- (Earring) Energy Earring +1
+					13440,	2000,		-- (Ring) Ascetic's Ring
+					13548,	50000,		-- (Ring) Astral Ring
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_WHM =
+				{
+					17141,	15000,		-- (Club) Solid Wand
+					17409,	15000,		-- (Club) Mythril Rod +1
+					17121,	15000,		-- (Club) Maul +1
+					17534,	15000,		-- (Staff) Whale Staff +1
+					17119,	15000,		-- (Staff) Elm Pole +1
+					18137,	5000,		-- (Ammunition) Holy Ampulla
+					12538,  10000,      -- (Head) Red Cap +1
+					12625,  10000,      -- (Body) Gambison +1
+					12779,  10000,      -- (Hands) Bracers +1
+					12903,  10000,      -- (Legs) Hose +1
+					13034,  10000,      -- (Feet) Socks +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13233,	5000,		-- (Waist) Gold Obi +1
+					13618,	5000,		-- (Back) White Cape +1
+					14702,	5000,		-- (Earring) Aura Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_WHM =
+				{
+					17427,	25000,		-- (Club) Ebony Wand +1
+					17435,	25000,		-- (Club) Darksteel Rod +1
+					17432,	25000,		-- (Club) Darksteel Maul +1
+					17520,	25000,		-- (Staff) Heavy Staff +1
+					17521,	25000,		-- (Staff) Mahogany Pole +1
+					15227,	50000,		-- (Head) Healer's Cap +1
+					14475,	50000,		-- (Body) Healer's Briault +1
+					14892,	50000,		-- (Hands) Healer's Mitts +1
+					15563,	50000,		-- (Legs) Healer's Pantaloons +1
+					15354,	50000,		-- (Feet) Healer's Duckbills +1
+					15887,	10000,		-- (Neck) Resolute Belt
+					15885,	10000,		-- (Neck) Spectral Belt
+					15490,	10000,		-- (Back) Miraculous Cape
+					15971,	10000,		-- (Earring) Antivenom Earring
+					15972,	10000,		-- (Earring) Insomnia Earring
+					15776,	10000,		-- (Ring) Ebullient Ring
+					15777,	10000,		-- (Ring) Hale Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_WHM =
+				{
+					18874,	40000,		-- (Club) Brise-os +1
+					17568,	40000,		-- (Staff) Eight-sided Pole +1
+					17277,	20000,		-- (Ammunition) Hedgehog Bomb
+					11066,	50000,		-- (Head) Orison Cap +2
+					11086,	50000,		-- (Body) Orison Bliaud +2
+					11106,	50000,		-- (Hands) Orison Mitts +2
+					11126,	50000,		-- (Legs) Orison Pantaloons +2
+					11146,	50000,		-- (Feet) Orison Duckbills +2
+					11615,  50000,		-- (Neck) Orison Locket
+					11705,  50000,		-- (Earring) Orison Earring
+					11554,  50000,		-- (Back) Orison Cape
+					10652,	50000,		-- (Head) Cleric's Cap +2
+					10672,	50000,		-- (Body) Cleric's Briault +2
+					10692,	50000,		-- (Hands) Cleric's Mitts +2
+					10712,	50000,		-- (Legs) Cleric's Pantaloons +2
+					10732,	50000,		-- (Feet) Cleric's Duckbills +2
+					11579,	30000,		-- (Neck) Fylgja Torque
+					15949,	30000,		-- (Waist) Pythia Sash +1
+					27598,	30000,		-- (Back) Dew Silk Cape +1
+					11683,	30000,		-- (Earring) Aqua Earring
+					13308,	30000,		-- (Ring) Communion Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_WHM =
+				{
+					21133,	100000,		-- (Club) Sasah Wand +1
+					21132,	100000,		-- (Club) Aedold
+					21208,	100000,		-- (Staff) Lehbrailg
+					19780,	30000,		-- (Ammunition) Mana Ampulla
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11066,	50000,		-- (Head) Orison Cap +2
+					11086,	50000,		-- (Body) Orison Bliaud +2
+					11106,	50000,		-- (Hands) Orison Mitts +2
+					11126,	50000,		-- (Legs) Orison Pantaloons +2
+					11146,	50000,		-- (Feet) Orison Duckbills +2
+					11615,  50000,		-- (Neck) Orison Locket
+					11705,  50000,		-- (Earring) Orison Earring
+					11554,  50000,		-- (Back) Orison Cape
+					10652,	50000,		-- (Head) Cleric's Cap +2
+					10672,	50000,		-- (Body) Cleric's Briault +2
+					10692,	50000,		-- (Hands) Cleric's Mitts +2
+					10712,	50000,		-- (Legs) Cleric's Pantaloons +2
+					10732,	50000,		-- (Feet) Cleric's Duckbills +2
+					-- 25429,	50000,		-- (Neck) Cleric's Torque
+					28455,	50000,		-- (Waist) Ovate Rope
+					28596,	50000,		-- (Back) Oretania's Cape +1
+					-- 28474,	50000,		-- (Earring) Mendicant's Earring
+					-- 11054,	50000,		-- (Earring) Pensee Earring
+					11683,	30000,		-- (Earring) Aqua Earring
+					-- 27566,	50000,		-- (Ring) Leviathan Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_WHM)
+	elseif (job == xi.job.BLM) then
+		local stock_BLM = {}
+		player:PrintToPlayer(string.format("Andreine : Hmm, do you really need extra gear as a Black Mage? So overpowered!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_BLM =
+				{
+					17087,	5000,		-- (Club) Maple Wand +1
+					17123,	5000,		-- (Staff) Ash Staff +1
+					12744,	2000,		-- (Gloves) Cuffs +1
+					12897,  2000,       -- (Legs) Slops +1
+					12983,	2000,		-- (Feet) Ash Clogs +1
+					13093,	2000,		-- (Neck) Justice Badge
+					13190,	2000,		-- (Waist) Heko Obi +1
+					13605,	2000,		-- (Back) Cape +1
+					14694,	2000,		-- (Earring) Energy Earring +1
+					13475,	2000,		-- (Ring) Hermit's Ring
+					13548,	50000,		-- (Ring) Astral Ring
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_BLM =
+				{
+					17141,	15000,		-- (Club) Solid Wand
+					17409,	15000,		-- (Club) Mythril Rod +1
+					17534,	15000,		-- (Staff) Whale Staff +1
+					17119,	15000,		-- (Staff) Elm Pole +1
+					15173,  10000,      -- (Head) Kosshin
+					13730,  10000,      -- (Body) Frost Robe
+					12750,  10000,      -- (Hands) New Moon Armlets
+					12904,  10000,      -- (Legs) Linen Slacks +1
+					13040,  10000,      -- (Feet) Shoes +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13233,	5000,		-- (Waist) Gold Obi +1
+					13610,	5000,		-- (Back) Black Cape +1
+					14702,	5000,		-- (Earring) Aura Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_BLM =
+				{
+					17427,	25000,		-- (Club) Ebony Wand +1
+					17435,	25000,		-- (Club) Darksteel Rod +1
+					17520,	25000,		-- (Staff) Heavy Staff +1
+					17521,	25000,		-- (Staff) Mahogany Pole +1
+					15228,	50000,		-- (Head) Wizard's Petasos +1
+					14476,	50000,		-- (Body) Wizard's Coat +1
+					14893,	50000,		-- (Hands) Wizard's Gloves +1
+					15564,	50000,		-- (Legs) Wizard's Tonban +1
+					15355,	50000,		-- (Feet) Wizard's Sabots +1
+					15887,	10000,		-- (Neck) Resolute Belt
+					15885,	10000,		-- (Neck) Spectral Belt
+					15490,	10000,		-- (Back) Miraculous Cape
+					15971,	10000,		-- (Earring) Antivenom Earring
+					15972,	10000,		-- (Earring) Insomnia Earring
+					15776,	10000,		-- (Ring) Ebullient Ring
+					15777,	10000,		-- (Ring) Hale Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_BLM =
+				{
+					17118,	40000,		-- (Staff) Lituus +1
+					17277,	20000,		-- (Ammunition) Hedgehog Bomb
+					11067,	50000,		-- (Head) Goetia Petasos +2
+					11087,	50000,		-- (Body) Goetia Coat +2
+					11107,	50000,		-- (Hands) Goetia Gloves +2
+					11127,	50000,		-- (Legs) Goetia Chausses +2
+					11147,	50000,		-- (Feet) Goetia Sabots +2
+					11593,  50000,		-- (Neck) Goetia Chain
+					11706,  50000,		-- (Earring) Goetia Earring
+					16203,  50000,		-- (Back) Goetia Mantle
+					10653,	50000,		-- (Head) Sorcerer's Petasos +2
+					10673,	50000,		-- (Body) Sorcerer's Coat +2
+					10693,	50000,		-- (Hands) Sorcerer's Gloves +2
+					10713,	50000,		-- (Legs) Sorcerer's Tonban +2
+					10733,	50000,		-- (Feet) Sorcerer's Sabots +2
+					11584,	30000,		-- (Neck) Lemegeton Medallion +1
+					11743,	30000,		-- (Waist) Searing Sash
+					11560,	30000,		-- (Back) Pedant Cape
+					11682,	30000,		-- (Earring) Snow Earring
+					13306,	30000,		-- (Ring) Omniscient Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_BLM =
+				{
+					21133,	100000,		-- (Club) Sasah Wand +1
+					21208,	100000,		-- (Staff) Lehbrailg
+					-- 21362,	30000,		-- (Ammunition) Ombre Tathlum +1
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11067,	50000,		-- (Head) Goetia Petasos +2
+					11087,	50000,		-- (Body) Goetia Coat +2
+					11107,	50000,		-- (Hands) Goetia Gloves +2
+					11127,	50000,		-- (Legs) Goetia Chausses +2
+					11147,	50000,		-- (Feet) Goetia Sabots +2
+					11593,  50000,		-- (Neck) Goetia Chain
+					11706,  50000,		-- (Earring) Goetia Earring
+					16203,  50000,		-- (Back) Goetia Mantle
+					10653,	50000,		-- (Head) Sorcerer's Petasos +2
+					10673,	50000,		-- (Body) Sorcerer's Coat +2
+					10693,	50000,		-- (Hands) Sorcerer's Gloves +2
+					10713,	50000,		-- (Legs) Sorcerer's Tonban +2
+					10733,	50000,		-- (Feet) Sorcerer's Sabots +2
+					-- 25435,	50000,		-- (Neck) Sorcerer's Stole
+					10839,	50000,		-- (Waist) Othila Sash
+					28601,	50000,		-- (Back) Seshaw Cape
+					11682,	30000,		-- (Earring) Snow Earring
+					-- 27574,	50000,		-- (Ring) Shiva Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_BLM)
+	elseif (job == xi.job.RDM) then
+		local stock_RDM = {}
+		player:PrintToPlayer(string.format("Andreine : Couldn't pick just one school of magic to focus on eh? That's ok, I've got gear for you!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_RDM =
+				{
+					16610,	5000,		-- (Sword) Wax Sword +1
+					17087,	5000,		-- (Club) Maple Wand +1
+					12744,	2000,		-- (Gloves) Cuffs +1
+					12897,  2000,       -- (Legs) Slops +1
+					12983,	2000,		-- (Feet) Ash Clogs +1
+					13093,	2000,		-- (Neck) Justice Badge
+					13190,	2000,		-- (Waist) Heko Obi +1
+					13605,	2000,		-- (Back) Cape +1
+					14694,	2000,		-- (Earring) Energy Earring +1
+					13440,	2000,		-- (Ring) Ascetic's Ring
+					13475,	2000,		-- (Ring) Hermit's Ring
+					13548,	50000,		-- (Ring) Astral Ring
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_RDM =
+				{
+					16815,  15000,      -- (Sword) Mythril Degen +1
+					12335,  10000,      -- (Shield) Targe +1
+					17141,	15000,		-- (Club) Solid Wand
+					17534,	15000,		-- (Staff) Whale Staff +1
+					12538,  10000,      -- (Head) Red Cap +1
+					12625,  10000,      -- (Body) Gambison +1
+					12779,  10000,      -- (Hands) Bracers +1
+					12903,  10000,      -- (Legs) Hose +1
+					13034,  10000,      -- (Feet) Socks +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13233,	5000,		-- (Waist) Gold Obi +1
+					13611,	7500,		-- (Back) Red Cape +1
+					14702,	5000,		-- (Earring) Aura Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_RDM =
+				{
+					17641,  25000,      -- (Sword) Gold Sword +1
+					12353,  25000,      -- (Shield) Gilt Buckler
+					17427,	25000,		-- (Club) Ebony Wand +1
+					17520,	25000,		-- (Staff) Heavy Staff +1
+					15229,	50000,		-- (Head) Warlock's Chapeau +1
+					14477,	50000,		-- (Body) Warlock's Tabard +1
+					14894,	50000,		-- (Hands) Warlock's Gloves +1
+					15565,	50000,		-- (Legs) Warlock's Tights +1
+					15356,	50000,		-- (Feet) Warlock's Boots +1
+					15887,	10000,		-- (Neck) Resolute Belt
+					15885,	10000,		-- (Neck) Spectral Belt
+					15490,	10000,		-- (Back) Miraculous Cape
+					15971,	10000,		-- (Earring) Antivenom Earring
+					15972,	10000,		-- (Earring) Insomnia Earring
+					15776,	10000,		-- (Ring) Ebullient Ring
+					15777,	10000,		-- (Ring) Hale Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_RDM =
+				{
+					17664,  40000,      -- (Sword) Firmament +1
+					12386,  40000,      -- (Shield) Acheron Shield +1
+					17277,	20000,		-- (Ammunition) Hedgehog Bomb
+					11068,	50000,		-- (Head) Estoqueur's Chappel +2
+					11088,	50000,		-- (Body) Estoqueur's Sayon +2
+					11108,	50000,		-- (Hands) Estoqueur's Gantherots +2
+					11128,	50000,		-- (Legs) Estoqueur's Fuseau +2
+					11148,	50000,		-- (Feet) Estoqueur's Houseaux +2
+					11594,  50000,		-- (Neck) Estoqueur's Collar
+					11707,  50000,		-- (Earring) Estoqueur's Earring
+					16204,  50000,		-- (Back) Estoqueur's Cape
+					10654,	50000,		-- (Head) Duelist's Chapeau +2
+					10674,	50000,		-- (Body) Duelist's Tabard +2
+					10694,	50000,		-- (Hands) Duelist's Gloves +2
+					10714,	50000,		-- (Legs) Duelist's Tights +2
+					10734,	50000,		-- (Feet) Duelist's Boots +2
+					11579,	30000,		-- (Neck) Fylgja Torque
+					11584,	30000,		-- (Neck) Lemegeton Medallion +1
+					11747,	30000,		-- (Waist) Austerity Belt
+					16210,	30000,		-- (Back) Ebullient Cape
+					16052,	30000,		-- (Earring) Incubus Earring
+					11683,	30000,		-- (Earring) Aqua Earring
+					11682,	30000,		-- (Earring) Snow Earring
+					13308,	30000,		-- (Ring) Communion Ring
+					13306,	30000,		-- (Ring) Omniscient Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_RDM =
+				{
+					20743,	100000,		-- (Sword) Bihkah Sword +1
+					28668,  100000,     -- (Shield) Matamata Shield +1
+					21207,	100000,		-- (Staff) Hemolele Staff +1
+					-- 21362,	30000,		-- (Ammunition) Ombre Tathlum +1
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11068,	50000,		-- (Head) Estoqueur's Chappel +2
+					11088,	50000,		-- (Body) Estoqueur's Sayon +2
+					11108,	50000,		-- (Hands) Estoqueur's Gantherots +2
+					11128,	50000,		-- (Legs) Estoqueur's Fuseau +2
+					11148,	50000,		-- (Feet) Estoqueur's Houseaux +2
+					11594,  50000,		-- (Neck) Estoqueur's Collar
+					11707,  50000,		-- (Earring) Estoqueur's Earring
+					16204,  50000,		-- (Back) Estoqueur's Cape
+					10654,	50000,		-- (Head) Duelist's Chapeau +2
+					10674,	50000,		-- (Body) Duelist's Tabard +2
+					10694,	50000,		-- (Hands) Duelist's Gloves +2
+					10714,	50000,		-- (Legs) Duelist's Tights +2
+					10734,	50000,		-- (Feet) Duelist's Boots +2
+					-- 25441,	50000,		-- (Neck) Duelist's Torque
+					10839,	50000,		-- (Waist) Othila Sash
+					28455,	50000,		-- (Waist) Ovate Rope
+					28596,	50000,		-- (Back) Oretania's Cape +1
+					28601,	50000,		-- (Back) Seshaw Cape
+					11683,	30000,		-- (Earring) Aqua Earring
+					11682,	30000,		-- (Earring) Snow Earring
+					-- 27566,	50000,		-- (Ring) Leviathan Ring
+					-- 27574,	50000,		-- (Ring) Shiva Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_RDM)
+	elseif (job == xi.job.THF) then
+		local stock_THF = {}
+		player:PrintToPlayer(string.format("Andreine : Please keep in mind that my wares are for sale and not lifting by sticky fingers!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_THF =
+				{
+					16610,	5000,		-- (Sword) Wax Sword +1
+					16690,	5000,		-- (Hand-to-Hand) Cesti +1
+					16491,	5000,		-- (Dagger) Bronze Knife +1
+					16492,	5000,		-- (Dagger) Bronze Dagger +1
+					17175,	5000,		-- (Archery) Shortbow +1
+					19225,	5000,		-- (Marksmanship) Musketoon +1
+					17290,	5000,		-- (Throwing) Coarse Boomerang
+					4219,	200,		-- (Ammunition) Stone Arrow Quiver
+					5359,	200,		-- (Ammunition) Bronze Bullet Pouch
+					12695,	2000,		-- (Gloves) Bronze Mittens +1
+					12823,  2000,       -- (Legs) Bronze Subligar +1
+					12951,	2000,		-- (Feet) Bronze Leggings +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_THF =
+				{
+					19106,	10000,      -- (Dagger) Thug's Jambiya +1
+					17260,	15000,		-- (Marksmanship) Pirate's Gun +1
+					5363,	2000,		-- (Ammunition) Bullet Pouch
+					12538,  10000,      -- (Head) Red Cap +1
+					12625,  10000,      -- (Body) Gambison +1
+					12779,  10000,      -- (Hands) Bracers +1
+					12903,  10000,      -- (Legs) Hose +1
+					13034,  10000,      -- (Feet) Socks +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_THF =
+				{
+					17603,  15000,      -- (Dagger) Cermet Kukri +1
+					19227,	25000,		-- (Marksmanship) Blunderbuss +1
+					5353,	5000,		-- (Ammunition) Iron Bullet Pouch
+					15230,	50000,		-- (Head) Rogue's Bonnet +1
+					14478,	50000,		-- (Body) Rogue's Vest +1
+					14895,	50000,		-- (Hands) Rogue's Armlets +1
+					15566,	50000,		-- (Legs) Rogue's Culottes +1
+					15357,	50000,		-- (Feet) Rogue's Poulaines +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13369,	10000,		-- (Earring) Spike Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_THF =
+				{
+					16481,  35000,      -- (Dagger) Yataghan +1
+					17252,	40000,		-- (Marksmanship) Culverin
+					5353,	5000,		-- (Ammunition) Iron Bullet Pouch
+					17342,	75,			-- (Ammunition) Cannon Shell
+					11069,	50000,		-- (Head) Raider's Bonnet +2
+					11089,	50000,		-- (Body) Raider's Vest +2
+					11109,	50000,		-- (Hands) Raider's Armlets +2
+					11129,	50000,		-- (Legs) Raider's Culottes +2
+					11149,	50000,		-- (Feet) Raider's Poulaines +2 (TH)
+					19260,  50000,		-- (Throwing) Raider's Boomerang
+					11708,  50000,		-- (Earring) Raider's Earring
+					11736,  50000,		-- (Waist) Raider's Belt
+					10655,	50000,		-- (Head) Assassin's Bonnet +2
+					10675,	50000,		-- (Body) Assassin's Vest +2
+					10695,	50000,		-- (Hands) Assassin's Armlets +2 (TH)
+					10715,	50000,		-- (Legs) Assassin's Culottes +2
+					10735,	50000,		-- (Feet) Assassin's Poulaines +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11681,	30000,		-- (Earring) Breeze Earring
+					11679,	30000,		-- (Earring) Thunder Earring
+					14636,	30000,		-- (Ring) Breeze Ring
+					14638,	30000,		-- (Ring) Thunder Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_THF =
+				{
+					20642,	65000,		-- (Dagger) Tzustes Knife +1
+					19742,  100000,     -- (Marksmanship) Handgonne +1
+					5353,	5000,		-- (Ammunition) Iron Bullet Pouch
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11069,	50000,		-- (Head) Raider's Bonnet +2
+					11089,	50000,		-- (Body) Raider's Vest +2
+					11109,	50000,		-- (Hands) Raider's Armlets +2
+					11129,	50000,		-- (Legs) Raider's Culottes +2
+					11149,	50000,		-- (Feet) Raider's Poulaines +2 (TH)
+					19260,  50000,		-- (Throwing) Raider's Boomerang
+					11708,  50000,		-- (Earring) Raider's Earring
+					11736,  50000,		-- (Waist) Raider's Belt
+					10655,	50000,		-- (Head) Assassin's Bonnet +2
+					10675,	50000,		-- (Body) Assassin's Vest +2
+					10695,	50000,		-- (Hands) Assassin's Armlets +2 (TH)
+					10715,	50000,		-- (Legs) Assassin's Culottes +2
+					10735,	50000,		-- (Feet) Assassin's Poulaines +2
+					-- 25447,	50000,		-- (Neck) Assassin's Gorget
+					10831,	50000,		-- (Waist) Paewr Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_THF)
+	elseif (job == xi.job.PLD) then
+		local stock_PLD = {}
+		player:PrintToPlayer(string.format("Andreine : You're going to need to soak up a lot of damage as a Paladin! I hope this gear helps!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_PLD =
+				{
+					16627,	5000,		-- (Sword) Spatha +1
+					12371,	5000,		-- (Shield) Clipeus
+					17175,	5000,		-- (Archery) Shortbow +1
+					4219,	200,		-- (Ammunition) Stone Arrow Quiver
+					12784,	2000,		-- (Gloves) Leather Gloves +1
+					12908,  2000,       -- (Legs) Leather Trousers +1
+					12971,	2000,		-- (Feet) Leather Highboots +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					14670,	2000,		-- (Ring) Safeguard Ring
+					13548,	50000,		-- (Ring) Astral Ring
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_PLD =
+				{
+					16812,  15000,      -- (Sword) War Sword
+					12335,  10000,      -- (Shield) Targe +1
+					17179,	15000,		-- (Archery) Composite Bow +1
+					4222,	2000,		-- (Ammunition) Horn Arrow Quiver
+					12533,  10000,      -- (Head) Silver Mask +1
+					12666,  10000,      -- (Body) Silver Mail +1
+					12772,  10000,      -- (Hands) Silver Mittens +1
+					12894,  10000,      -- (Legs) Silver Hose +1
+					13029,  10000,      -- (Feet) Silver Greaves +1
+					13070,	5000,		-- (Neck) Wolf Gorget +1
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13506,	5000,		-- (Ring) Bomb Ring
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_PLD =
+				{
+					17641,  25000,      -- (Sword) Gold Sword +1
+					12353,  25000,      -- (Shield) Gilt Buckler
+					17189,	25000,		-- (Archery) Rapid Bow +1
+					4224,	5000,		-- (Ammunition) Demon Arrow Quiver
+					15231,	50000,		-- (Head) Gallant Coronet +1
+					14479,	50000,		-- (Body) Gallant Surcoat +1
+					14896,	50000,		-- (Hands) Gallant Gauntlets +1
+					15567,	50000,		-- (Legs) Gallant Breeches +1
+					15358,	50000,		-- (Feet) Gallant Leggings +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15887,	10000,		-- (Waist) Resolute Belt
+					13691,	10000,		-- (Back) Knightly Mantle
+					14758,	10000,		-- (Earring) Knightly Earring
+					16009,	10000,		-- (Earring) Pennon Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_PLD =
+				{
+					17664,  40000,      -- (Sword) Firmament +1
+					16163,  40000,      -- (Shield) Januwiyah +1
+					18682,	40000,		-- (Archery) Lamian Kaman +1
+					5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
+					11070,	50000,		-- (Head) Creed Armet +2
+					11090,	50000,		-- (Body) Creed Cuirass +2
+					11110,	50000,		-- (Hands) Creed Gauntlets +2
+					11130,	50000,		-- (Legs) Creed Cuisses +2
+					11150,	50000,		-- (Feet) Creed Sabatons +2
+					11595,  50000,		-- (Neck) Creed Collar
+					11709,  50000,		-- (Earring) Creed Earring
+					11750,  50000,		-- (Waist) Creed Baudrier
+					10656,	50000,		-- (Head) Valor Coronet +2
+					10676,	50000,		-- (Body) Valor Surcoat +2
+					10696,	50000,		-- (Hands) Valor Gauntlets +2
+					10716,	50000,		-- (Legs) Valor Breeches +2
+					10736,	50000,		-- (Feet) Valor Leggings +2
+					10929,	30000,		-- (Neck) Apathy Gorget
+					15895,	30000,		-- (Waist) Trance Belt (AH price)
+					16216,	30000,		-- (Back) Cerberus Mantle +1
+					11680,	30000,		-- (Earring) Soil Earring
+					14634,	30000,		-- (Ring) Soil Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_PLD =
+				{
+					20743,	100000,		-- (Sword) Bihkah Sword +1
+					28668,  100000,     -- (Shield) Matamata Shield +1
+					19785,	100000,		-- (Archery) Lanner Bow +1
+					6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
+					10442,  300000,		-- (Head) Laeradr Helm
+					10280,  300000,		-- (Body) Laeradr Breastplate
+					10435,	100000,		-- (Head) Dux Visor +1
+					10273,	100000,		-- (Body) Dux Scale Mail +1
+					10317,	100000,		-- (Hands) Dux Finger Gauntlets +1
+					10347,	100000,		-- (Legs) Dux Cuisses +1
+					10364,	100000,		-- (Feet) Dux Greaves +1
+					11070,	50000,		-- (Head) Creed Armet +2
+					11090,	50000,		-- (Body) Creed Cuirass +2
+					11110,	50000,		-- (Hands) Creed Gauntlets +2
+					11130,	50000,		-- (Legs) Creed Cuisses +2
+					11150,	50000,		-- (Feet) Creed Sabatons +2
+					11595,  50000,		-- (Neck) Creed Collar
+					11709,  50000,		-- (Earring) Creed Earring
+					11750,  50000,		-- (Waist) Creed Baudrier
+					10656,	50000,		-- (Head) Valor Coronet +2
+					10676,	50000,		-- (Body) Valor Surcoat +2
+					10696,	50000,		-- (Hands) Valor Gauntlets +2
+					10716,	50000,		-- (Legs) Valor Breeches +2
+					10736,	50000,		-- (Feet) Valor Leggings +2
+					-- 25453,	50000,		-- (Neck) Knight's Bead Necklace
+					10819,	50000,		-- (Waist) Flume Belt
+					10996,	50000,		-- (Back) Testudo Mantle
+					11050,	50000,		-- (Earring) Puissant Pearl
+					11039,	50000,		-- (Earring) Brachyura Earring
+					10798,	50000,		-- (Ring) Eihwaz Ring
+					28577,	50000,		-- (Ring) Kunaji Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_PLD)
+	elseif (job == xi.job.DRK) then
+		local stock_DRK = {}
+		player:PrintToPlayer(string.format("Andreine : I know you're always hungry for more souls as a Dark Knight but don't forget to eat food too!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_DRK =
+				{
+					16778,	5000,		-- (Scythe) Bronze Zaghnal +1
+					16606,	5000,		-- (Great Sword) Rusty Greatsword
+					16637,	5000,		-- (Great Sword) Deathbringer
+					16716,	5000,		-- (Great Axe) Butterfly Axe +1
+					17228,	5000,		-- (Marksmanship) Light Crossbow +1
+					4227,	200,		-- (Ammunition) Bronze Bolt Quiver
+					12784,	2000,		-- (Gloves) Leather Gloves +1
+					12908,  2000,       -- (Legs) Leather Trousers +1
+					12971,	2000,		-- (Feet) Leather Highboots +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_DRK =
+				{
+					16797,  15000,      -- (Scythe) Mythril Zaghnal +1
+					16936,	15000,		-- (Great Sword) Demonic Sword
+					17229,	15000,		-- (Marksmanship) Zamburak +1
+					4228,	2000,		-- (Ammunition) Mythril Bolt Quiver
+					12533,  10000,      -- (Head) Silver Mask +1
+					12666,  10000,      -- (Body) Silver Mail +1
+					12772,  10000,      -- (Hands) Silver Mittens +1
+					12894,  10000,      -- (Legs) Silver Hose +1
+					13029,  10000,      -- (Feet) Silver Greaves +1
+					13070,	5000,		-- (Neck) Wolf Gorget +1
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13519,	5000,		-- (Ring) Mythril Ring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_DRK =
+				{
+					16790,  25000,      -- (Scythe) Darksteel Scythe +1
+					16616,	25000,		-- (Great Sword) Zweihander +1
+					17227,	25000,		-- (Marksmanship) Heavy Crossbow +1
+					4229,	5000,		-- (Ammunition) Darksteel Bolt Quiver
+					15232,	50000,		-- (Head) Chaos Burgeonet +1
+					14480,	50000,		-- (Body) Chaos Cuirass +1
+					14897,	50000,		-- (Hands) Chaos Gauntlets +1
+					15568,	50000,		-- (Legs) Chaos Flanchard +1
+					15359,	50000,		-- (Feet) Chaos Sollerets +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13403,	10000,		-- (Earring) Assault Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_DRK =
+				{
+					18965,	40000,		-- (Scythe) Dire Scythe +1
+					19166,	40000,		-- (Great Sword) Cratus Sword +1
+					19266,	40000,		-- (Marksmanship) Darkwing +1
+					5821,	7500,		-- (Ammunition) Fusion Bolt Quiver
+					11071,	50000,		-- (Head) Bale Burgeonet +2
+					11091,	50000,		-- (Body) Bale Cuirass +2
+					11111,	50000,		-- (Hands) Bale Gauntlets +2
+					11131,	50000,		-- (Legs) Bale Flanchard +2
+					11151,	50000,		-- (Feet) Bale Sollerets +2
+					11616,  50000,		-- (Neck) Bale Choker
+					11710,  50000,		-- (Earring) Bale Earring
+					11737,  50000,		-- (Waist) Bale Belt
+					10657,	50000,		-- (Head) Abyss Burgeonet +2
+					10677,	50000,		-- (Body) Abyss Cuirass +2
+					10697,	50000,		-- (Hands) Abyss Gauntlets +2
+					10717,	50000,		-- (Legs) Abyss Flanchard +2
+					10737,	50000,		-- (Feet) Abyss Sollerets +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11678,	30000,		-- (Earring) Flame Earring
+					14630,	30000,		-- (Ring) Flame Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_DRK =
+				{
+					18916,  300000,		-- (Sword) Heimdall's Doom
+					20923,	100000,		-- (Scythe) Aak'ab Scythe +1
+					20788,	100000,		-- (Great Sword) Hatzoaar Sword +1
+					19266,	40000,		-- (Marksmanship) Darkwing +1
+					6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
+					10442,  300000,		-- (Head) Laeradr Helm
+					10280,  300000,		-- (Body) Laeradr Breastplate
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11071,	50000,		-- (Head) Bale Burgeonet +2
+					11091,	50000,		-- (Body) Bale Cuirass +2
+					11111,	50000,		-- (Hands) Bale Gauntlets +2
+					11131,	50000,		-- (Legs) Bale Flanchard +2
+					11151,	50000,		-- (Feet) Bale Sollerets +2
+					11616,  50000,		-- (Neck) Bale Choker
+					11710,  50000,		-- (Earring) Bale Earring
+					11737,  50000,		-- (Waist) Bale Belt
+					10657,	50000,		-- (Head) Abyss Burgeonet +2
+					10677,	50000,		-- (Body) Abyss Cuirass +2
+					10697,	50000,		-- (Hands) Abyss Gauntlets +2
+					10717,	50000,		-- (Legs) Abyss Flanchard +2
+					10737,	50000,		-- (Feet) Abyss Sollerets +2
+					-- 25459,	50000,		-- (Neck) Abyssal Bead Necklace
+					10831,	50000,		-- (Waist) Paewr Belt
+					10819,	50000,		-- (Waist) Flume Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_DRK)
+	elseif (job == xi.job.BST) then
+		local stock_BST = {}
+		player:PrintToPlayer(string.format("Andreine : You're lucky to always have a friend as a Beastmaster! I miss my pets..."),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_BST =
+				{
+					16646,	5000,		-- (Axe) Bronze Axe +1
+					16778,	5000,		-- (Scythe) Bronze Zaghnal +1
+					12695,	2000,		-- (Gloves) Bronze Mittens +1
+					12823,  2000,       -- (Legs) Bronze Subligar +1
+					12951,	2000,		-- (Feet) Bronze Leggings +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13072,	2000,		-- (Neck) Bird Whistle
+					13110,	2000,		-- (Neck) Beast Whistle
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_BST =
+				{
+					16664,	15000,		-- (Axe) War Pick +1
+					12335,  10000,      -- (Shield) Targe +1
+					16797,  15000,      -- (Scythe) Mythril Zaghnal +1
+					12533,  10000,      -- (Head) Silver Mask +1
+					12666,  10000,      -- (Body) Silver Mail +1
+					12772,  10000,      -- (Hands) Silver Mittens +1
+					12894,  10000,      -- (Legs) Silver Hose +1
+					13029,  10000,      -- (Feet) Silver Greaves +1
+					13070,	5000,		-- (Neck) Wolf Gorget +1
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13519,	5000,		-- (Ring) Mythril Ring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_BST =
+				{
+					16682,	25000,		-- (Axe) Darksteel Pick +1
+					12353,  25000,      -- (Shield) Gilt Buckler
+					18962,  25000,      -- (Scythe) Rusty Zaghnal
+					15233,	50000,		-- (Head) Beast Helm +1
+					14481,	50000,		-- (Body) Beast Jackcoat +1
+					14898,	50000,		-- (Hands) Beast Gloves +1
+					15569,	50000,		-- (Legs) Beast Trousers +1
+					15360,	50000,		-- (Feet) Beast Gaiters +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13403,	10000,		-- (Earring) Assault Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_BST =
+				{
+					16662,	40000,		-- (Axe) Doom Tabar +1
+					12386,  40000,      -- (Shield) Acheron Shield +1
+					18963,	40000,		-- (Scythe) Gleaming Zaghnal
+					11072,	50000,		-- (Head) Ferine Cabasset +2
+					11092,	50000,		-- (Body) Ferine Gausape +2
+					11112,	50000,		-- (Hands) Ferine Manoplas +2
+					11132,	50000,		-- (Legs) Ferine Quijotes +2
+					11152,	50000,		-- (Feet) Ferine Ocreae +2
+					11617,  50000,		-- (Neck) Ferine Necklace
+					11711,  50000,		-- (Earring) Ferine Earring
+					11555,  50000,		-- (Back) Ferine Mantle
+					10658,	50000,		-- (Head) Monster Helm +2
+					10678,	50000,		-- (Body) Monster Jackcoat +2
+					10698,	50000,		-- (Hands) Monster Gloves +2
+					10718,	50000,		-- (Legs) Monster Trousers +2
+					10738,	50000,		-- (Feet) Monster Gaiters +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11678,	30000,		-- (Earring) Flame Earring
+					14630,	30000,		-- (Ring) Flame Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_BST =
+				{
+					20832,	65000,		-- (Axe) Aalak' Axe +1
+					28668,  100000,     -- (Shield) Matamata Shield +1
+					18562,	100000,		-- (Scythe) Yhatdhara +1
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11072,	50000,		-- (Head) Ferine Cabasset +2
+					11092,	50000,		-- (Body) Ferine Gausape +2
+					11112,	50000,		-- (Hands) Ferine Manoplas +2
+					11132,	50000,		-- (Legs) Ferine Quijotes +2
+					11152,	50000,		-- (Feet) Ferine Ocreae +2
+					11617,  50000,		-- (Neck) Ferine Necklace
+					11711,  50000,		-- (Earring) Ferine Earring
+					11555,  50000,		-- (Back) Ferine Mantle
+					10658,	50000,		-- (Head) Monster Helm +2
+					10678,	50000,		-- (Body) Monster Jackcoat +2
+					10698,	50000,		-- (Hands) Monster Gloves +2
+					10718,	50000,		-- (Legs) Monster Trousers +2
+					10738,	50000,		-- (Feet) Monster Gaiters +2
+					-- 25465,	50000,		-- (Neck) Beastmaster Collar
+					10831,	50000,		-- (Waist) Paewr Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_BST)
+	elseif (job == xi.job.BRD) then
+		local stock_BRD = {}
+		player:PrintToPlayer(string.format("Andreine : Your audiences will expect only the finest from their Bard!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_BRD =
+				{
+					16610,	5000,		-- (Sword) Wax Sword +1
+					16491,	5000,		-- (Dagger) Bronze Knife +1
+					16492,	5000,		-- (Dagger) Bronze Dagger +1
+					17372,	5000,		-- (Wind Instrument) Flute +1
+					17373,	5000,		-- (String Instrument) Maple Harp +1
+					12744,	2000,		-- (Gloves) Cuffs +1
+					12897,  2000,       -- (Legs) Slops +1
+					12983,	2000,		-- (Feet) Ash Clogs +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13072,	2000,		-- (Neck) Bird Whistle
+					13190,	2000,		-- (Waist) Heko Obi +1
+					13605,	2000,		-- (Back) Cape +1
+					14694,	2000,		-- (Earring) Energy Earring +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					13548,	50000,		-- (Ring) Astral Ring
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_BRD =
+				{
+					16815,	15000,      -- (Sword) Mythril Degen +1
+					17375,	10000,		-- (Wind Instrument) Traversiere +1
+					17376,	10000,		-- (String Instrument) Rose Harp +1
+					12538,  10000,      -- (Head) Red Cap +1
+					12625,  10000,      -- (Body) Gambison +1
+					12779,  10000,      -- (Hands) Bracers +1
+					12903,  10000,      -- (Legs) Hose +1
+					13034,  10000,      -- (Feet) Socks +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_BRD =
+				{
+					16618,  25000,      -- (Sword) Mailbreaker +1
+					17832,	15000,		-- (Wind Instrument) Shofar +1
+					17833,	15000,		-- (String Instrument) Ebony Harp +1
+					15234,	50000,		-- (Head) Choral Roundlet +1
+					14482,	50000,		-- (Body) Choral Justaucorps +1
+					14899,	50000,		-- (Hands) Choral Cuffs +1
+					15570,	50000,		-- (Legs) Choral Cannions +1
+					15361,	50000,		-- (Feet) Choral Slippers +1
+					15524,	10000,		-- (Neck) Fortified Chain
+					15525,	10000,		-- (Neck) Grandiose Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15887,	10000,		-- (Neck) Resolute Belt
+					15490,	10000,		-- (Back) Miraculous Cape
+					16009,	10000,		-- (Earring) Pennon Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_BRD =
+				{
+					17719,  40000,      -- (Sword) Mensur Epee
+					11073,	50000,		-- (Head) Aoidos' Calot +2
+					11093,	50000,		-- (Body) Aoidos' Hongreline +2
+					11113,	50000,		-- (Hands) Aoidos' Manchettes +2
+					11133,	50000,		-- (Legs) Aoidos' Rhingrave +2
+					11153,	50000,		-- (Feet) Aoidos' Cothurnes +2
+					11618,  50000,		-- (Neck) Aoidos' Matinee
+					11712,  50000,		-- (Earring) Aoidos' Earring
+					11738,  50000,		-- (Waist) Aoidos' Belt
+					10659,	50000,		-- (Head) Bard's Roundlet +2
+					10679,	50000,		-- (Body) Bard's Justaucorps +2
+					10699,	50000,		-- (Hands) Bard's Cuffs +2
+					10719,	50000,		-- (Legs) Bard's Cannions +2
+					10739,	50000,		-- (Feet) Bard's Slippers +2
+					11608,	30000,		-- (Neck) Barcarolle Medal
+					11745,	30000,		-- (Waist) Aristo Belt
+					11563,	30000,		-- (Back) Mesmeric Cape
+					11724,	30000,		-- (Earring) Reverie Earring +1
+					14643,	30000,		-- (Ring) Apollo's Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_BRD =
+				{
+					20743,	100000,		-- (Sword) Bihkah Sword +1
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11073,	50000,		-- (Head) Aoidos' Calot +2
+					11093,	50000,		-- (Body) Aoidos' Hongreline +2
+					11113,	50000,		-- (Hands) Aoidos' Manchettes +2
+					11133,	50000,		-- (Legs) Aoidos' Rhingrave +2
+					11153,	50000,		-- (Feet) Aoidos' Cothurnes +2
+					11618,  50000,		-- (Neck) Aoidos' Matinee
+					11712,  50000,		-- (Earring) Aoidos' Earring
+					11738,  50000,		-- (Waist) Aoidos' Belt
+					10659,	50000,		-- (Head) Bard's Roundlet +2
+					10679,	50000,		-- (Body) Bard's Justaucorps +2
+					10699,	50000,		-- (Hands) Bard's Cuffs +2
+					10719,	50000,		-- (Legs) Bard's Cannions +2
+					10739,	50000,		-- (Feet) Bard's Slippers +2
+					-- 25471,	50000,		-- (Neck) Bard's Charm
+					10826,	50000,		-- (Waist) Witful Belt
+					11012,	50000,		-- (Back) Gwyddion's Cape
+					11036,	50000,		-- (Earring) Enchanter's Earring
+					11701,	50000,		-- (Earring) Skald Breloque
+					-- 27576,	50000,		-- (Ring) Carbuncle Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_BRD)
+	elseif (job == xi.job.RNG) then
+		local stock_RNG = {}
+		player:PrintToPlayer(string.format("Andreine : I had no idea there were so many types of ranged weapons! How do you Rangers choose?"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_RNG =
+				{
+					16610,	5000,		-- (Sword) Wax Sword +1
+					16491,	5000,		-- (Dagger) Bronze Knife +1
+					16492,	5000,		-- (Dagger) Bronze Dagger +1
+					17175,	5000,		-- (Archery) Shortbow +1
+					17177,	5000,		-- (Archery) Longbow +1
+					17228,	5000,		-- (Marksmanship) Light Crossbow +1
+					19225,	5000,		-- (Marksmanship) Musketoon +1
+					4219,	200,		-- (Ammunition) Stone Arrow Quiver
+					4227,	200,		-- (Ammunition) Bronze Bolt Quiver
+					5359,	200,		-- (Ammunition) Bronze Bullet Pouch
+					12744,	2000,		-- (Gloves) Cuffs +1
+					12897,  2000,       -- (Legs) Slops +1
+					12983,	2000,		-- (Feet) Ash Clogs +1
+					13060,	2000,		-- (Neck) Feather Collar +1
+					13117,	2000,		-- (Neck) Ranger's Necklace
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_RNG =
+				{
+					19106,	10000,      -- (Dagger) Thug's Jambiya +1
+					17180,	15000,		-- (Archery) Great Bow +1
+					17229,	15000,		-- (Marksmanship) Zamburak +1
+					17260,	15000,		-- (Marksmanship) Pirate's Gun +1
+					4222,	2000,		-- (Ammunition) Horn Arrow Quiver
+					4228,	2000,		-- (Ammunition) Mythril Bolt Quiver
+					5363,	2000,		-- (Ammunition) Bullet Pouch
+					15161,  10000,      -- (Head) Noct Beret
+					14422,  10000,      -- (Body) Noct Doublet
+					14854,  10000,      -- (Hands) Noct Gloves
+					14323,  10000,      -- (Legs) Noct Brais
+					15311,  10000,      -- (Feet) Noct Gaiters
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_RNG =
+				{
+					17603,  15000,      -- (Dagger) Cermet Kukri +1
+					17189,	25000,		-- (Archery) Rapid Bow +1
+					17227,	25000,		-- (Marksmanship) Heavy Crossbow +1
+					19227,	25000,		-- (Marksmanship) Blunderbuss +1
+					4224,	5000,		-- (Ammunition) Demon Arrow Quiver
+					4229,	5000,		-- (Ammunition) Darksteel Bolt Quiver
+					5353,	5000,		-- (Ammunition) Iron Bullet Pouch
+					15235,	50000,		-- (Head) Hunter's Beret +1
+					14483,	50000,		-- (Body) Hunter's Jerkin +1
+					14900,	50000,		-- (Hands) Hunter's Bracers +1
+					15571,	50000,		-- (Legs) Hunter's Braccae +1
+					15362,	50000,		-- (Feet) Hunter's Socks +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13369,	10000,		-- (Earring) Spike Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_RNG =
+				{
+					16481,  35000,      -- (Dagger) Yataghan +1
+					18701,	40000,		-- (Archery) Cerberus Bow +1
+					19266,	40000,		-- (Marksmanship) Darkwing +1
+					19268,	40000,		-- (Marksmanship) Ribauldequin +1
+					5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
+					5821,	7500,		-- (Ammunition) Fusion Bolt Quiver
+					5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
+					11074,	50000,		-- (Head) Sylvan Gapette +2
+					11094,	50000,		-- (Body) Sylvan Caban +2
+					11114,	50000,		-- (Hands) Sylvan Glovelettes +2
+					11134,	50000,		-- (Legs) Sylvan Bragues +2
+					11154,	50000,		-- (Feet) Sylvan Bottillons +2
+					11596,  50000,		-- (Neck) Sylvan Scarf
+					11713,  50000,		-- (Earring) Sylvan Earring
+					16205,  50000,		-- (Back) Sylvan Chlamys
+					10660,	50000,		-- (Head) Scout's Beret +2
+					10680,	50000,		-- (Body) Scout's Jerkin +2
+					10700,	50000,		-- (Hands) Scout's Bracers +2
+					10720,	50000,		-- (Legs) Scout's Braccae +2
+					10740,	50000,		-- (Feet) Scout's Socks +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11681,	30000,		-- (Earring) Breeze Earring
+					14636,	30000,		-- (Ring) Breeze Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_RNG =
+				{
+					20642,	65000,		-- (Dagger) Tzustes Knife +1
+					21244,  100000,     -- (Archery) Ahkormaar Bow +1
+					21259,  100000,     -- (Marksmanship) Malayo Crossbow +1
+					21293,  100000,     -- (Marksmanship) Bandeiras Gun +1
+					6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
+					6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
+					6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11074,	50000,		-- (Head) Sylvan Gapette +2
+					11094,	50000,		-- (Body) Sylvan Caban +2
+					11114,	50000,		-- (Hands) Sylvan Glovelettes +2
+					11134,	50000,		-- (Legs) Sylvan Bragues +2
+					11154,	50000,		-- (Feet) Sylvan Bottillons +2
+					11596,  50000,		-- (Neck) Sylvan Scarf
+					11713,  50000,		-- (Earring) Sylvan Earring
+					16205,  50000,		-- (Back) Sylvan Chlamys
+					10660,	50000,		-- (Head) Scout's Beret +2
+					10680,	50000,		-- (Body) Scout's Jerkin +2
+					10700,	50000,		-- (Hands) Scout's Bracers +2
+					10720,	50000,		-- (Legs) Scout's Braccae +2
+					10740,	50000,		-- (Feet) Scout's Socks +2
+					-- 25477,	50000,		-- (Neck) Scout's Gorget
+					11735,  50000,		-- (Waist) Impulse Belt
+					--26337,	50000,		-- (Waist) Kwahu Kachina Belt
+					11006,	50000,		-- (Back) Thall Mantle
+					11046,	50000,		-- (Earring) Ouesk Pearl
+					28513,	50000,		-- (Earring) Phawaylla Earring
+					11058,	50000,		-- (Ring) Hajduk Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_RNG)
+	elseif (job == xi.job.SAM) then
+		local stock_SAM = {}
+		player:PrintToPlayer(string.format("Andreine : Well met noble Samurai! There are demons which must taste the steel of your blade."),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_SAM =
+				{
+					17809,	5000,		-- (Great Katana) Mumeito
+					17177,	5000,		-- (Archery) Longbow +1
+					4219,	200,		-- (Ammunition) Stone Arrow Quiver
+					12774,	2000,		-- (Gloves) Tekko +1
+					12899,	2000,       -- (Legs) Sitabaki +1
+					13031,	2000,		-- (Feet) Kyahan +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_SAM =
+				{
+					16988,  15000,      -- (Great Katana) Kotetsu
+					17180,	15000,		-- (Archery) Great Bow +1
+					4222,	2000,		-- (Ammunition) Horn Arrow Quiver
+					12539,  10000,      -- (Head) Soil Hachimaki +1
+					12671,  10000,      -- (Body) Soil Gi +1
+					12781,  10000,      -- (Hands) Soil Tekko +1
+					12905,  10000,      -- (Legs) Soil Sitabaki +1
+					13035,  10000,      -- (Feet) Soil Kyahan +1
+					13070,	5000,		-- (Neck) Wolf Gorget +1
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13519,	5000,		-- (Ring) Mythril Ring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_SAM =
+				{
+					16990,  25000,      -- (Great Katana) Daihannya
+					17189,	25000,		-- (Archery) Rapid Bow +1
+					4224,	5000,		-- (Ammunition) Demon Arrow Quiver
+					15236,	50000,		-- (Head) Myochin Kabuto +1
+					14484,	50000,		-- (Body) Myochin Domaru +1
+					14901,	50000,		-- (Hands) Myochin Kote +1
+					15572,	50000,		-- (Legs) Myochin Haidate +1
+					15363,	50000,		-- (Feet) Myochin Sune-Ate +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13369,	10000,		-- (Earring) Spike Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_SAM =
+				{
+					16977,	40000,		-- (Great Katana) Yukitsugu +1
+					18701,	40000,		-- (Archery) Cerberus Bow +1
+					5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
+					11075,	50000,		-- (Head) Unkai Kabuto +2
+					11095,	50000,		-- (Body) Unkai Domaru +2
+					11115,	50000,		-- (Hands) Unkai Kote +2
+					11135,	50000,		-- (Legs) Unkai Haidate +2
+					11155,	50000,		-- (Feet) Unkai Sune-Ate +2
+					11597,  50000,		-- (Neck) Unkai Nodowa
+					11714,  50000,		-- (Earring) Unkai Mimikazari
+					16206,  50000,		-- (Back) Unkai Sugemino
+					10661,	50000,		-- (Head) Saotome Kabuto +2
+					10681,	50000,		-- (Body) Saotome Domaru +2
+					10701,	50000,		-- (Hands) Saotome Kote +2
+					10721,	50000,		-- (Legs) Saotome Haidate +2
+					10741,	50000,		-- (Feet) Saotome Sune-Ate +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11678,	30000,		-- (Earring) Flame Earring
+					14630,	30000,		-- (Ring) Flame Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_SAM =
+				{
+					21057,	100000,		-- (Great Katana) Tomonari +1
+					19787,  100000,     -- (Archery) Nurigomeyumi +1
+					6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11075,	50000,		-- (Head) Unkai Kabuto +2
+					11095,	50000,		-- (Body) Unkai Domaru +2
+					11115,	50000,		-- (Hands) Unkai Kote +2
+					11135,	50000,		-- (Legs) Unkai Haidate +2
+					11155,	50000,		-- (Feet) Unkai Sune-Ate +2
+					11597,  50000,		-- (Neck) Unkai Nodowa
+					11714,  50000,		-- (Earring) Unkai Mimikazari
+					16206,  50000,		-- (Back) Unkai Sugemino
+					10661,	50000,		-- (Head) Saotome Kabuto +2
+					10681,	50000,		-- (Body) Saotome Domaru +2
+					10701,	50000,		-- (Hands) Saotome Kote +2
+					10721,	50000,		-- (Legs) Saotome Haidate +2
+					10741,	50000,		-- (Feet) Saotome Sune-Ate +2
+					-- 25483,	50000,		-- (Neck) Samurai's Nodowa
+					10831,	50000,		-- (Waist) Paewr Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_SAM)
+	elseif (job == xi.job.NIN) then
+		local stock_NIN = {}
+		player:PrintToPlayer(string.format("Andreine : Oh! You Ninjas always startle me when you appear out of nowhere like that!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_NIN =
+				{
+					16914,	5000,		-- (Katana) Kunai +1
+					17307,	2,			-- (Throwing) Dart
+					6299,	500,		-- (Throwing) Shuriken Pouch
+					12774,	2000,		-- (Gloves) Tekko +1
+					12899,	2000,       -- (Legs) Sitabaki +1
+					13031,	2000,		-- (Feet) Kyahan +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_NIN =
+				{
+					16921,  10000,      -- (Katana) Kodachi +1
+					6297,	2000,		-- (Throwing) Juji Shuriken Pouch
+					12539,  10000,      -- (Head) Soil Hachimaki +1
+					12671,  10000,      -- (Body) Soil Gi +1
+					12781,  10000,      -- (Hands) Soil Tekko +1
+					12905,  10000,      -- (Legs) Soil Sitabaki +1
+					13035,  10000,      -- (Feet) Soil Kyahan +1
+					13070,	5000,		-- (Neck) Wolf Gorget +1
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13519,	5000,		-- (Ring) Mythril Ring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_NIN =
+				{
+					16923,  15000,      -- (Katana) Kabutowari +1
+					6302,	5000,		-- (Throwing) Fuma Shuriken Pouch
+					15237,	50000,		-- (Head) Ninja Hatsuburi +1
+					14485,	50000,		-- (Body) Ninja Chainmail +1
+					14902,	50000,		-- (Hands) Ninja Tekko +1
+					15573,	50000,		-- (Legs) Ninja Hakama +1
+					15364,	50000,		-- (Feet) Ninja Kyahan +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13369,	10000,		-- (Earring) Spike Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_NIN =
+				{
+					19286,	35000,		-- (Katana) Kakko +1
+					6300,	7500,		-- (Throwing) Koga Shuriken Pouch
+					11076,	50000,		-- (Head) Iga Zukin +2
+					11096,	50000,		-- (Body) Iga Ningi +2
+					11116,	50000,		-- (Hands) Iga Tekko +2
+					11136,	50000,		-- (Legs) Iga Hakama +2
+					11156,	50000,		-- (Feet) Iga Kyahan +2
+					11598,  50000,		-- (Neck) Iga Erimaki
+					11715,  50000,		-- (Earring) Iga Mimikazari
+					16207,  50000,		-- (Back) Iga Dochugappa
+					10662,	50000,		-- (Head) Koga Hatsuburi +2
+					10682,	50000,		-- (Body) Koga Chainmail +2
+					10702,	50000,		-- (Hands) Koga Tekko +2
+					10722,	50000,		-- (Legs) Koga Hakama +2
+					10742,	50000,		-- (Feet) Koga Kyahan +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11678,	30000,		-- (Earring) Flame Earring
+					14630,	30000,		-- (Ring) Flame Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_NIN =
+				{
+					21010,	65000,		-- (Katana) Nakajimarai +1
+					6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11076,	50000,		-- (Head) Iga Zukin +2
+					11096,	50000,		-- (Body) Iga Ningi +2
+					11116,	50000,		-- (Hands) Iga Tekko +2
+					11136,	50000,		-- (Legs) Iga Hakama +2
+					11156,	50000,		-- (Feet) Iga Kyahan +2
+					11598,  50000,		-- (Neck) Iga Erimaki
+					11715,  50000,		-- (Earring) Iga Mimikazari
+					16207,  50000,		-- (Back) Iga Dochugappa
+					10662,	50000,		-- (Head) Koga Hatsuburi +2
+					10682,	50000,		-- (Body) Koga Chainmail +2
+					10702,	50000,		-- (Hands) Koga Tekko +2
+					10722,	50000,		-- (Legs) Koga Hakama +2
+					10742,	50000,		-- (Feet) Koga Kyahan +2
+					-- 25489,	50000,		-- (Neck) Ninja Nodowa
+					10831,	50000,		-- (Waist) Paewr Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					28492,  50000,      -- (Earring) Hibernation Earring
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_NIN)
+	elseif (job == xi.job.DRG) then
+		local stock_DRG = {}
+		player:PrintToPlayer(string.format("Andreine : It's so good to see a Dragoon again! Give your wyvern a special treat from me!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_DRG =
+				{
+					16862,	5000,		-- (Polearm) Harpoon +1
+					12695,	2000,		-- (Gloves) Bronze Mittens +1
+					12823,  2000,       -- (Legs) Bronze Subligar +1
+					12951,	2000,		-- (Feet) Bronze Leggings +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_DRG =
+				{
+					16876,  15000,      -- (Polearm) Lance +1
+					13824,  10000,      -- (Head) Strong Bandana
+					13707,  10000,      -- (Body) Strong Vest
+					12786,  10000,      -- (Hands) Strong Gloves
+					12910,  10000,      -- (Legs) Strong Trousers
+					13039,  10000,      -- (Feet) Strong Boots
+					13070,	5000,		-- (Neck) Wolf Gorget +1
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13519,	5000,		-- (Ring) Mythril Ring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_DRG =
+				{
+					18119,  25000,      -- (Polearm) Dark Mezraq +1
+					18259,	200,		-- (Ammunition) Angon
+					15238,	50000,		-- (Head) Drachen Armet +1
+					14486,	50000,		-- (Body) Drachen Mail +1
+					14903,	50000,		-- (Hands) Drachen Finger Gauntlets +1
+					15574,	50000,		-- (Legs) Drachen Brais +1
+					15365,	50000,		-- (Feet) Drachen Greaves +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13403,	10000,		-- (Earring) Assault Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_DRG =
+				{
+					18111,	40000,		-- (Polearm) Mezraq +1
+					18259,	200,		-- (Ammunition) Angon
+					11077,	50000,		-- (Head) Lancer's Mezail +2
+					11097,	50000,		-- (Body) Lancer's Plackart +2
+					11117,	50000,		-- (Hands) Lancer's Vambraces +2
+					11137,	50000,		-- (Legs) Lancer's Cuissots +2
+					11157,	50000,		-- (Feet) Lancer's Schynbalds +2
+					11599,  50000,		-- (Neck) Lancer's Torque
+					11716,  50000,		-- (Earring) Lancer's Earring
+					16208,  50000,		-- (Back) Lancer's Pelerine
+					10663,	50000,		-- (Head) Wyrm Armet +2
+					10683,	50000,		-- (Body) Wyrm Mail +2
+					10703,	50000,		-- (Hands) Wyrm Finger Gauntlets +2
+					10723,	50000,		-- (Legs) Wyrm Brais +2
+					10743,	50000,		-- (Feet) Wyrm Greaves +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11678,	30000,		-- (Earring) Flame Earring
+					14630,	30000,		-- (Ring) Flame Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_DRG =
+				{
+					19799,  300000,		-- (Polearm) Herja's Fork
+					20968,	100000,		-- (Polearm) Chanar Xyston +1
+					18259,	200,		-- (Ammunition) Angon
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11077,	50000,		-- (Head) Lancer's Mezail +2
+					11097,	50000,		-- (Body) Lancer's Plackart +2
+					11117,	50000,		-- (Hands) Lancer's Vambraces +2
+					11137,	50000,		-- (Legs) Lancer's Cuissots +2
+					11157,	50000,		-- (Feet) Lancer's Schynbalds +2
+					11599,  50000,		-- (Neck) Lancer's Torque
+					11716,  50000,		-- (Earring) Lancer's Earring
+					16208,  50000,		-- (Back) Lancer's Pelerine
+					10663,	50000,		-- (Head) Wyrm Armet +2
+					10683,	50000,		-- (Body) Wyrm Mail +2
+					10703,	50000,		-- (Hands) Wyrm Finger Gauntlets +2
+					10723,	50000,		-- (Legs) Wyrm Brais +2
+					10743,	50000,		-- (Feet) Wyrm Greaves +2
+					-- 25495,	50000,		-- (Neck) Dragoon's Collar
+					10831,	50000,		-- (Waist) Paewr Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_DRG)
+	elseif (job == xi.job.SMN) then
+		local stock_SMN = {}
+		player:PrintToPlayer(string.format("Andreine : Greetings noble Summoner! Are all of the avatars getting along today?"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_SMN =
+				{
+					17123,	5000,		-- (Staff) Ash Staff +1
+					17122,	5000,		-- (Staff) Ash Pole +1
+					12744,	2000,		-- (Gloves) Cuffs +1
+					12897,  2000,       -- (Legs) Slops +1
+					12983,	2000,		-- (Feet) Ash Clogs +1
+					13093,	2000,		-- (Neck) Justice Badge
+					13190,	2000,		-- (Waist) Heko Obi +1
+					13605,	2000,		-- (Back) Cape +1
+					14694,	2000,		-- (Earring) Energy Earring +1
+					13440,	2000,		-- (Ring) Ascetic's Ring
+					13548,	50000,		-- (Ring) Astral Ring
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_SMN =
+				{
+					17534,	15000,		-- (Staff) Whale Staff +1
+					17119,	15000,		-- (Staff) Elm Pole +1
+					12538,  10000,      -- (Head) Red Cap +1
+					12625,  10000,      -- (Body) Gambison +1
+					12779,  10000,      -- (Hands) Bracers +1
+					12903,  10000,      -- (Legs) Hose +1
+					13034,  10000,      -- (Feet) Socks +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13233,	5000,		-- (Waist) Gold Obi +1
+					13618,	5000,		-- (Back) White Cape +1
+					14702,	5000,		-- (Earring) Aura Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_SMN =
+				{
+					17520,	25000,		-- (Staff) Heavy Staff +1
+					17521,	25000,		-- (Staff) Mahogany Pole +1
+					15239,	50000,		-- (Head) Evoker's Horn +1
+					14487,	50000,		-- (Body) Evoker's Doublet +1
+					14904,	50000,		-- (Hands) Evoker's Bracers +1
+					15575,	50000,		-- (Legs) Evoker's Spats +1
+					15366,	50000,		-- (Feet) Evoker's Pigaches +1
+					15887,	10000,		-- (Neck) Resolute Belt
+					15885,	10000,		-- (Neck) Spectral Belt
+					15490,	10000,		-- (Back) Miraculous Cape
+					15971,	10000,		-- (Earring) Antivenom Earring
+					15972,	10000,		-- (Earring) Insomnia Earring
+					15776,	10000,		-- (Ring) Ebullient Ring
+					15777,	10000,		-- (Ring) Hale Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_SMN =
+				{
+					17578,	40000,		-- (Staff) Zen Pole
+					17277,	20000,		-- (Ammunition) Hedgehog Bomb
+					11078,	50000,		-- (Head) Caller's Horn +2
+					11098,	50000,		-- (Body) Caller's Doublet +2
+					11118,	50000,		-- (Hands) Caller's Bracers +2
+					11138,	50000,		-- (Legs) Caller's Spats +2
+					11158,	50000,		-- (Feet) Caller's Pigaches +2
+					11619,  50000,		-- (Neck) Caller's Pendant
+					11717,  50000,		-- (Earring) Caller's Earring
+					11739,  50000,		-- (Back) Caller's Sash
+					10664,	50000,		-- (Head) Summoner's Horn +2
+					10684,	50000,		-- (Body) Summoner's Doublet +2
+					10704,	50000,		-- (Hands) Summoner's Bracers +2
+					10724,	50000,		-- (Legs) Summoner's Spats +2
+					10744,	50000,		-- (Feet) Summoner's Pigaches +2
+					11579,	30000,		-- (Neck) Fylgja Torque
+					15949,	30000,		-- (Waist) Pythia Sash +1
+					11564,	30000,		-- (Back) Tiresias' Cape
+					11685,	30000,		-- (Earring) Darkness Earring
+					14644,	30000,		-- (Ring) Dark Ring
+					14625,  100000,		-- (Ring) Evoker's Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_SMN =
+				{
+					21208,	100000,		-- (Staff) Lehbrailg
+					19780,	30000,		-- (Ammunition) Mana Ampulla
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11078,	50000,		-- (Head) Caller's Horn +2
+					11098,	50000,		-- (Body) Caller's Doublet +2
+					11118,	50000,		-- (Hands) Caller's Bracers +2
+					11138,	50000,		-- (Legs) Caller's Spats +2
+					11158,	50000,		-- (Feet) Caller's Pigaches +2
+					11619,  50000,		-- (Neck) Caller's Pendant
+					11717,  50000,		-- (Earring) Caller's Earring
+					11739,  50000,		-- (Back) Caller's Sash
+					10664,	50000,		-- (Head) Summoner's Horn +2
+					10684,	50000,		-- (Body) Summoner's Doublet +2
+					10704,	50000,		-- (Hands) Summoner's Bracers +2
+					10724,	50000,		-- (Legs) Summoner's Spats +2
+					10744,	50000,		-- (Feet) Summoner's Pigaches +2
+					-- 25501,	50000,		-- (Neck) Summoner's Collar
+					10842,	50000,		-- (Waist) Bougonia Rope
+					27607,	50000,		-- (Back) Thaumaturge's Cape
+					11021,	30000,		-- (Earring) Darkness Pearl
+					-- 27578,	30000,		-- (Ring) Fenrir Ring
+					14625,  100000,		-- (Ring) Evoker's Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_SMN)
+	elseif (job == xi.job.BLU) then
+		local stock_BLU = {}
+		player:PrintToPlayer(string.format("Andreine : You may know the secrets of monster techniques Blue Mage but I have the gear you'll need!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_BLU =
+				{
+					16610,	5000,		-- (Sword) Wax Sword +1
+					12695,	2000,		-- (Gloves) Bronze Mittens +1
+					12823,  2000,       -- (Legs) Bronze Subligar +1
+					12951,	2000,		-- (Feet) Bronze Leggings +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13190,	2000,		-- (Waist) Heko Obi +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					14694,	2000,		-- (Earring) Energy Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_BLU =
+				{
+					17740,  15000,      -- (Sword) Steel Kilij +1
+					15173,  10000,      -- (Head) Kosshin
+					13730,  10000,      -- (Body) Frost Robe
+					12750,  10000,      -- (Hands) New Moon Armlets
+					12904,  10000,      -- (Legs) Linen Slacks +1
+					13040,  10000,      -- (Feet) Shoes +1
+					13070,	5000,		-- (Neck) Wolf Gorget +1
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13506,	5000,		-- (Ring) Bomb Ring
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_BLU =
+				{
+					17639,  25000,      -- (Sword) Cutlass +1
+					11464,	50000,		-- (Head) Magus Keffiyeh +1
+					11291,	50000,		-- (Body) Magus Jubbah +1
+					15024,	50000,		-- (Hands) Magus Bazubands +1
+					16345,	50000,		-- (Legs) Magus Shalwar +1
+					11381,	50000,		-- (Feet) Magus Charuqs +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15887,	10000,		-- (Waist) Resolute Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13369,	10000,		-- (Earring) Spike Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_BLU =
+				{
+					17664,  40000,      -- (Sword) Firmament +1
+					11079,	50000,		-- (Head) Mavi Kavuk +2
+					11099,	50000,		-- (Body) Mavi Mintan +2
+					11119,	50000,		-- (Hands) Mavi Bazubands +2
+					11139,	50000,		-- (Legs) Mavi Tayt +2
+					11159,	50000,		-- (Feet) Mavi Basmak +2
+					19255,  50000,		-- (Ammunition) Mavi Tathlum
+					11600,  50000,		-- (Neck) Mavi Scarf
+					11718,  50000,		-- (Earring) Mavi Earring
+					10665,	50000,		-- (Head) Mirage Keffiyeh +2
+					10685,	50000,		-- (Body) Mirage Jubbah +2
+					10705,	50000,		-- (Hands) Mirage Bazubands +2
+					10725,	50000,		-- (Legs) Mirage Shalwar +2
+					10745,	50000,		-- (Feet) Mirage Charuqs +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11678,	30000,		-- (Earring) Flame Earring
+					14630,	30000,		-- (Ring) Flame Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_BLU =
+				{
+					18916,  300000,		-- (Sword) Heimdall's Doom
+					20743,	100000,		-- (Sword) Bihkah Sword +1
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11079,	50000,		-- (Head) Mavi Kavuk +2
+					11099,	50000,		-- (Body) Mavi Mintan +2
+					11119,	50000,		-- (Hands) Mavi Bazubands +2
+					11139,	50000,		-- (Legs) Mavi Tayt +2
+					11159,	50000,		-- (Feet) Mavi Basmak +2
+					19255,  50000,		-- (Ammunition) Mavi Tathlum
+					11600,  50000,		-- (Neck) Mavi Scarf
+					11718,  50000,		-- (Earring) Mavi Earring
+					10665,	50000,		-- (Head) Mirage Keffiyeh +2
+					10685,	50000,		-- (Body) Mirage Jubbah +2
+					10705,	50000,		-- (Hands) Mirage Bazubands +2
+					10725,	50000,		-- (Legs) Mirage Shalwar +2
+					10745,	50000,		-- (Feet) Mirage Charuqs +2
+					-- 25507,	50000,		-- (Neck) Mirage Stole
+					10831,	50000,		-- (Waist) Paewr Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_BLU)
+	elseif (job == xi.job.COR) then
+		local stock_COR = {}
+		player:PrintToPlayer(string.format("Andreine : Ready to roll the dice Corsair? I wish you the best of luck out there!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_COR =
+				{
+					16624,	5000,		-- (Sword) Xiphos +1
+					16491,	5000,		-- (Dagger) Bronze Knife +1
+					19225,	5000,		-- (Marksmanship) Musketoon +1
+					5359,	200,		-- (Ammunition) Bronze Bullet Pouch
+					12695,	2000,		-- (Gloves) Bronze Mittens +1
+					12823,  2000,       -- (Legs) Bronze Subligar +1
+					12951,	2000,		-- (Feet) Bronze Leggings +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_COR =
+				{
+					19106,	10000,      -- (Dagger) Thug's Jambiya +1
+					17260,	15000,		-- (Marksmanship) Pirate's Gun +1
+					5363,	2000,		-- (Ammunition) Bullet Pouch
+					15161,  10000,      -- (Head) Noct Beret
+					14422,  10000,      -- (Body) Noct Doublet
+					14854,  10000,      -- (Hands) Noct Gloves
+					14323,  10000,      -- (Legs) Noct Brais
+					15311,  10000,      -- (Feet) Noct Gaiters
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_COR =
+				{
+					17603,  15000,      -- (Dagger) Cermet Kukri +1
+					19227,	25000,		-- (Marksmanship) Blunderbuss +1
+					5353,	5000,		-- (Ammunition) Iron Bullet Pouch
+					11467,	50000,		-- (Head) Corsair's Tricorne +1
+					11294,	50000,		-- (Body) Corsair's Frac +1
+					15027,	50000,		-- (Hands) Corsair's Gants +1
+					16348,	50000,		-- (Legs) Corsair's Culottes +1
+					11384,	50000,		-- (Feet) Corsair's Bottes +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13369,	10000,		-- (Earring) Spike Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_COR =
+				{
+					16481,  35000,      -- (Dagger) Yataghan +1
+					19268,	40000,		-- (Marksmanship) Ribauldequin +1
+					5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
+					11080,	50000,		-- (Head) Navarch's Tricorne +2
+					11100,	50000,		-- (Body) Navarch's Frac +2
+					11120,	50000,		-- (Hands) Navarch's Gants +2
+					11140,	50000,		-- (Legs) Navarch's Culottes +2
+					11160,	50000,		-- (Feet) Navarch's Bottes +2
+					11601,  50000,		-- (Neck) Navarch's Choker
+					11719,  50000,		-- (Earring) Navarch's Earring
+					16209,  50000,		-- (Back) Navarch's Mantle
+					10666,	50000,		-- (Head) Commodore Tricorne +2
+					10686,	50000,		-- (Body) Commodore Frac +2
+					10706,	50000,		-- (Hands) Commodore Gants +2
+					10726,	50000,		-- (Legs) Commodore Trews +2
+					10746,	50000,		-- (Feet) Commodore Bottes +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11681,	30000,		-- (Earring) Breeze Earring
+					14636,	30000,		-- (Ring) Breeze Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_COR =
+				{
+					20642,	65000,		-- (Dagger) Tzustes Knife +1
+					21293,  100000,     -- (Marksmanship) Bandeiras Gun +1
+					6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11080,	50000,		-- (Head) Navarch's Tricorne +2
+					11100,	50000,		-- (Body) Navarch's Frac +2
+					11120,	50000,		-- (Hands) Navarch's Gants +2
+					11140,	50000,		-- (Legs) Navarch's Culottes +2
+					11160,	50000,		-- (Feet) Navarch's Bottes +2
+					11601,  50000,		-- (Neck) Navarch's Choker
+					11719,  50000,		-- (Earring) Navarch's Earring
+					16209,  50000,		-- (Back) Navarch's Mantle
+					10666,	50000,		-- (Head) Commodore Tricorne +2
+					10686,	50000,		-- (Body) Commodore Frac +2
+					10706,	50000,		-- (Hands) Commodore Gants +2
+					10726,	50000,		-- (Legs) Commodore Trews +2
+					10746,	50000,		-- (Feet) Commodore Bottes +2
+					-- 25513,	50000,		-- (Neck) Commodore Charm
+					26337,	50000,		-- (Waist) Kwahu Kachina Belt
+					11006,	50000,		-- (Back) Thall Mantle
+					11046,	50000,		-- (Earring) Ouesk Pearl
+					28513,	50000,		-- (Earring) Phawaylla Earring
+					-- 27572,	50000,		-- (Ring) Garuda Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_COR)
+	elseif (job == xi.job.PUP) then
+		local stock_PUP = {}
+		player:PrintToPlayer(string.format("Andreine : Oh, how wonderful to see a Puppetmaster! Such finesse in controlling your puppet!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_PUP =
+				{
+					17476,	5000,		-- (Hand-to-Hand) Cat Baghnakhs +1
+					17859,	1000,		-- (Ranged) Animator
+					12744,	2000,		-- (Gloves) Cuffs +1
+					12897,  2000,       -- (Legs) Slops +1
+					12983,	2000,		-- (Feet) Ash Clogs +1
+					16282,	2000,		-- (Neck) Buffoon's Collar +1
+					13226,	2000,		-- (Waist) Blood Stone +1
+					13605,	2000,		-- (Back) Cape +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_PUP =
+				{
+					16445,	15000,		-- (Hand-to-Hand) Claws +1
+					17858,	5000,		-- (Ranged) Turbo Animator
+					12538,  10000,      -- (Head) Red Cap +1
+					12625,  10000,      -- (Body) Gambison +1
+					12779,  10000,      -- (Hands) Bracers +1
+					12903,  10000,      -- (Legs) Hose +1
+					13034,  10000,      -- (Feet) Socks +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13233,	5000,		-- (Waist) Gold Obi +1
+					13643,	5000,		-- (Back) Sarcenet Cape +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13519,	5000,		-- (Ring) Mythril Ring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_PUP =
+				{
+					18751,  25000,      -- (Hand-to-Hand) Black Adargas +1
+					17857,	15000,		-- (Ranged) Animator +1
+					11470,	50000,		-- (Head) Puppetry Taj +1
+					11297,	50000,		-- (Body) Puppetry Tobe +1
+					15030,	50000,		-- (Hands) Puppetry Dastanas +1
+					16351,	50000,		-- (Legs) Puppetry Churidars +1
+					11387,	50000,		-- (Feet) Puppetry Babouches +1
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15492,	10000,		-- (Back) Intensifying Cape
+					13369,	10000,		-- (Earring) Spike Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_PUP =
+				{
+					18775,	40000,		-- (Hand-to-Hand) Savate Fists +1
+					17923,	25000,		-- (Ranged) Deluxe Animator
+					19249,	20000,		-- (Ammunition) Thew Bomblet
+					11081,	50000,		-- (Head) Cirque Capello +2
+					11101,	50000,		-- (Body) Cirque Farsetto +2
+					11121,	50000,		-- (Hands) Cirque Guanti +2
+					11141,	50000,		-- (Legs) Cirque Pantaloni +2
+					11161,	50000,		-- (Feet) Cirque Scarpe +2
+					11602,  50000,		-- (Neck) Cirque Necklace
+					11720,  50000,		-- (Earring) Cirque Earring
+					11751,  50000,		-- (Waist) Cirque Sash
+					10667,	50000,		-- (Head) Pantin Taj +2
+					10687,	50000,		-- (Body) Pantin Tobe +2
+					10707,	50000,		-- (Hands) Pantin Dastanas +2
+					10727,	50000,		-- (Legs) Pantin Churidars +2
+					10747,	50000,		-- (Feet) Pantin Babouches +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11678,	30000,		-- (Earring) Flame Earring
+					14630,	30000,		-- (Ring) Flame Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_PUP =
+				{
+					20552,	100000,		-- (Hand-to-Hand) Akua Sainti +1
+					17923,	25000,		-- (Ranged) Deluxe Animator
+					19249,	20000,		-- (Ammunition) Thew Bomblet
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11081,	50000,		-- (Head) Cirque Capello +2
+					11101,	50000,		-- (Body) Cirque Farsetto +2
+					11121,	50000,		-- (Hands) Cirque Guanti +2
+					11141,	50000,		-- (Legs) Cirque Pantaloni +2
+					11161,	50000,		-- (Feet) Cirque Scarpe +2
+					11602,  50000,		-- (Neck) Cirque Necklace
+					11720,  50000,		-- (Earring) Cirque Earring
+					11751,  50000,		-- (Waist) Cirque Sash
+					10667,	50000,		-- (Head) Pantin Taj +2
+					10687,	50000,		-- (Body) Pantin Tobe +2
+					10707,	50000,		-- (Hands) Pantin Dastanas +2
+					10727,	50000,		-- (Legs) Pantin Churidars +2
+					10747,	50000,		-- (Feet) Pantin Babouches +2
+					-- 25519,	50000,		-- (Neck) Puppetmaster's Collar
+					10831,	50000,		-- (Waist) Paewr Belt
+					10987,	50000,		-- (Back) Meanagh Cape
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_PUP)
+	elseif (job == xi.job.DNC) then
+		local stock_DNC = {}
+		player:PrintToPlayer(string.format("Andreine : The graceful movements of you Dancers are always so hypnotizing!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_DNC =
+				{
+					16690,	5000,		-- (Hand-to-Hand) Cesti +1
+					16491,	5000,		-- (Dagger) Bronze Knife +1
+					12695,	2000,		-- (Gloves) Bronze Mittens +1
+					12823,  2000,       -- (Legs) Bronze Subligar +1
+					12951,	2000,		-- (Feet) Bronze Leggings +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+			xi.shop.general(player, stock_DNC)
+		elseif (level <= 60) then
+			stock_DNC =
+				{
+					19106,	10000,      -- (Dagger) Thug's Jambiya +1
+					12538,  10000,      -- (Head) Red Cap +1
+					12625,  10000,      -- (Body) Gambison +1
+					12779,  10000,      -- (Hands) Bracers +1
+					12903,  10000,      -- (Legs) Hose +1
+					13034,  10000,      -- (Feet) Socks +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_DNC =
+				{
+					17603,  15000,      -- (Dagger) Cermet Kukri +1
+					11476,	50000,		-- (Head) Dancer's Tiara +1 (Female)
+					11303,	50000,		-- (Body) Dancer's Casaque +1 (Female)
+					15036,	50000,		-- (Hands) Dancer's Bangles +1 (Female)
+					16358,	50000,		-- (Legs) Dancer's Tights +1 (Female)
+					11394,	50000,		-- (Feet) Dancer's Toe Shoes +1 (Female)
+					11475,	50000,		-- (Head) Dancer's Tiara +1 (Male)
+					11302,	50000,		-- (Body) Dancer's Casaque +1 (Male)
+					15035,	50000,		-- (Hands) Dancer's Bangles +1 (Male)
+					16357,	50000,		-- (Legs) Dancer's Tights +1 (Male)
+					11393,	50000,		-- (Feet) Dancer's Toe Shoes +1 (Male)
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13369,	10000,		-- (Earring) Spike Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_DNC =
+				{
+					16481,  35000,      -- (Dagger) Yataghan +1
+					11082,	50000,		-- (Head) Charis Tiara +2
+					11102,	50000,		-- (Body) Charis Casaque +2
+					11122,	50000,		-- (Hands) Charis Bangles +2
+					11142,	50000,		-- (Legs) Charis Tights +2
+					11162,	50000,		-- (Feet) Charis Toe Shoes +2
+					19256,  50000,		-- (Ammunition) Charis Feather
+					11603,  50000,		-- (Neck) Charis Necklace
+					11721,  50000,		-- (Earring) Charis Earring
+					10668,	50000,		-- (Head) Etoile Tiara +2
+					10688,	50000,		-- (Body) Etoile Casaque +2
+					10708,	50000,		-- (Hands) Etoile Bangles +2
+					10728,	50000,		-- (Legs) Etoile Tights +2
+					10748,	50000,		-- (Feet) Etoile Toe Shoes +2
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11679,	30000,		-- (Earring) Thunder Earring
+					14638,	30000,		-- (Ring) Thunder Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_DNC =
+				{
+					20642,	65000,		-- (Dagger) Tzustes Knife +1
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11082,	50000,		-- (Head) Charis Tiara +2
+					11102,	50000,		-- (Body) Charis Casaque +2
+					11122,	50000,		-- (Hands) Charis Bangles +2
+					11142,	50000,		-- (Legs) Charis Tights +2
+					11162,	50000,		-- (Feet) Charis Toe Shoes +2
+					19256,  50000,		-- (Ammunition) Charis Feather
+					11603,  50000,		-- (Neck) Charis Necklace
+					11721,  50000,		-- (Earring) Charis Earring
+					10668,	50000,		-- (Head) Etoile Tiara +2
+					10688,	50000,		-- (Body) Etoile Casaque +2
+					10708,	50000,		-- (Hands) Etoile Bangles +2
+					10728,	50000,		-- (Legs) Etoile Tights +2
+					10748,	50000,		-- (Feet) Etoile Toe Shoes +2
+					-- 25525,	50000,		-- (Neck) Etoile Gorget
+					10831,	50000,		-- (Waist) Paewr Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_DNC)
+	elseif (job == xi.job.SCH) then
+		local stock_SCH = {}
+		player:PrintToPlayer(string.format("Andreine : You've got the book knowledge Scholar, now you just need the gear!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_SCH =
+				{
+					17087,	5000,		-- (Club) Maple Wand +1
+					17137,	5000,		-- (Club) Ash Club +1
+					17123,	5000,		-- (Staff) Ash Staff +1
+					17122,	5000,		-- (Staff) Ash Pole +1
+					12744,	2000,		-- (Gloves) Cuffs +1
+					12897,  2000,       -- (Legs) Slops +1
+					12983,	2000,		-- (Feet) Ash Clogs +1
+					13093,	2000,		-- (Neck) Justice Badge
+					13190,	2000,		-- (Waist) Heko Obi +1
+					13605,	2000,		-- (Back) Cape +1
+					14694,	2000,		-- (Earring) Energy Earring +1
+					13440,	2000,		-- (Ring) Ascetic's Ring
+					13475,	2000,		-- (Ring) Hermit's Ring
+					13548,	50000,		-- (Ring) Astral Ring
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+			xi.shop.general(player, stock_SCH)
+		elseif (level <= 60) then
+			stock_SCH =
+				{
+					17141,	15000,		-- (Club) Solid Wand
+					17409,	15000,		-- (Club) Mythril Rod +1
+					17534,	15000,		-- (Staff) Whale Staff +1
+					17119,	15000,		-- (Staff) Elm Pole +1
+					15173,  10000,      -- (Head) Kosshin
+					13730,  10000,      -- (Body) Frost Robe
+					12750,  10000,      -- (Hands) New Moon Armlets
+					12904,  10000,      -- (Legs) Linen Slacks +1
+					13040,  10000,      -- (Feet) Shoes +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13233,	5000,		-- (Waist) Gold Obi +1
+					13610,	5000,		-- (Back) Black Cape +1
+					14702,	5000,		-- (Earring) Aura Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_SCH =
+				{
+					17427,	25000,		-- (Club) Ebony Wand +1
+					17435,	25000,		-- (Club) Darksteel Rod +1
+					17520,	25000,		-- (Staff) Heavy Staff +1
+					17521,	25000,		-- (Staff) Mahogany Pole +1
+					11477,	50000,		-- (Head) Scholar's Mortarboard +1
+					11304,	50000,		-- (Body) Scholar's Gown +1
+					15037,	50000,		-- (Hands) Scholar's Bracers +1
+					16359,	50000,		-- (Legs) Scholar's Pants +1
+					11395,	50000,		-- (Feet) Scholar's Loafers +1
+					15887,	10000,		-- (Neck) Resolute Belt
+					15885,	10000,		-- (Neck) Spectral Belt
+					15490,	10000,		-- (Back) Miraculous Cape
+					15971,	10000,		-- (Earring) Antivenom Earring
+					15972,	10000,		-- (Earring) Insomnia Earring
+					15776,	10000,		-- (Ring) Ebullient Ring
+					15777,	10000,		-- (Ring) Hale Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_SCH =
+				{
+					17118,	40000,		-- (Staff) Lituus +1
+					17277,	20000,		-- (Ammunition) Hedgehog Bomb
+					11083,	50000,		-- (Head) Savant's Bonnet +2
+					11103,	50000,		-- (Body) Savant's Gown +2
+					11123,	50000,		-- (Hands) Savant's Bracers +2
+					11143,	50000,		-- (Legs) Savant's Pants +2
+					11163,	50000,		-- (Feet) Savant's Loafers +2
+					19247,  50000,		-- (Ammunition) Savant's Treatise
+					11620,  50000,		-- (Neck) Savant's Chain
+					11722,  50000,		-- (Earring) Savant's Earring
+					10669,	50000,		-- (Head) Argute Mortarboard +2
+					10689,	50000,		-- (Body) Argute Gown +2
+					10709,	50000,		-- (Hands) Argute Bracers +2
+					10729,	50000,		-- (Legs) Argute Pants +2
+					10749,	50000,		-- (Feet) Argute Loafers +2
+					11579,	30000,		-- (Neck) Fylgja Torque
+					11584,	30000,		-- (Neck) Lemegeton Medallion +1
+					15949,	30000,		-- (Waist) Pythia Sash +1
+					11743,	30000,		-- (Waist) Searing Sash
+					27598,	30000,		-- (Back) Dew Silk Cape +1
+					11560,	30000,		-- (Back) Pedant Cape
+					11683,	30000,		-- (Earring) Aqua Earring
+					11682,	30000,		-- (Earring) Snow Earring
+					13308,	30000,		-- (Ring) Communion Ring
+					13306,	30000,		-- (Ring) Omniscient Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_SCH =
+				{
+					21133,	100000,		-- (Club) Sasah Wand +1
+					21208,	100000,		-- (Staff) Lehbrailg
+					-- 21362,	30000,		-- (Ammunition) Ombre Tathlum +1
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					11083,	50000,		-- (Head) Savant's Bonnet +2
+					11103,	50000,		-- (Body) Savant's Gown +2
+					11123,	50000,		-- (Hands) Savant's Bracers +2
+					11143,	50000,		-- (Legs) Savant's Pants +2
+					11163,	50000,		-- (Feet) Savant's Loafers +2
+					19247,  50000,		-- (Ammunition) Savant's Treatise
+					11620,  50000,		-- (Neck) Savant's Chain
+					11722,  50000,		-- (Earring) Savant's Earring
+					10669,	50000,		-- (Head) Argute Mortarboard +2
+					10689,	50000,		-- (Body) Argute Gown +2
+					10709,	50000,		-- (Hands) Argute Bracers +2
+					10729,	50000,		-- (Legs) Argute Pants +2
+					10749,	50000,		-- (Feet) Argute Loafers +2
+					-- 25531,	50000,		-- (Neck) Argute Stole
+					28455,	50000,		-- (Waist) Ovate Rope
+					10839,	50000,		-- (Waist) Othila Sash
+					28596,	50000,		-- (Back) Oretania's Cape +1
+					28601,	50000,		-- (Back) Seshaw Cape
+					11683,	30000,		-- (Earring) Aqua Earring
+					11682,	30000,		-- (Earring) Snow Earring
+					13308,	30000,		-- (Ring) Communion Ring
+					13306,	30000,		-- (Ring) Omniscient Ring
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_SCH)
+	elseif (job == xi.job.GEO) then
+		local stock_GEO = {}
+		player:PrintToPlayer(string.format("Andreine : Geomancers are always so spaced out when they come in here!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_GEO =
+				{
+					17087,	5000,		-- (Club) Maple Wand +1
+					17137,	5000,		-- (Club) Ash Club +1
+					17144,	5000,		-- (Club) Bronze Hammer +1
+					21460,	1000,		-- (Handbell) Matre Bell
+					12744,	2000,		-- (Gloves) Cuffs +1
+					12897,  2000,       -- (Legs) Slops +1
+					12983,	2000,		-- (Feet) Ash Clogs +1
+					13093,	2000,		-- (Neck) Justice Badge
+					13190,	2000,		-- (Waist) Heko Obi +1
+					13605,	2000,		-- (Back) Cape +1
+					14694,	2000,		-- (Earring) Energy Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					13548,	50000,		-- (Ring) Astral Ring
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_GEO =
+				{
+					17141,	15000,		-- (Club) Solid Wand
+					17409,	15000,		-- (Club) Mythril Rod +1
+					15173,  10000,      -- (Head) Kosshin
+					13730,  10000,      -- (Body) Frost Robe
+					12750,  10000,      -- (Hands) New Moon Armlets
+					12904,  10000,      -- (Legs) Linen Slacks +1
+					13040,  10000,      -- (Feet) Shoes +1
+					13102,	5000,		-- (Neck) Paisley Scarf
+					13233,	5000,		-- (Waist) Gold Obi +1
+					13610,	5000,		-- (Back) Black Cape +1
+					14702,	5000,		-- (Earring) Aura Earring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_GEO =
+				{
+					17427,	25000,		-- (Club) Ebony Wand +1
+					17435,	25000,		-- (Club) Darksteel Rod +1
+					12141,	50000,		-- (Head) Ebon Beret
+					12177,	50000,		-- (Body)  Ebon Frock
+					12213,	50000,		-- (Hands) Ebon Mitts
+					12249,	50000,		-- (Legs) Ebon Slops
+					12285,	50000,		-- (Feet) Ebon Clogs
+					15887,	10000,		-- (Neck) Resolute Belt
+					15885,	10000,		-- (Neck) Spectral Belt
+					15490,	10000,		-- (Back) Miraculous Cape
+					15971,	10000,		-- (Earring) Antivenom Earring
+					15972,	10000,		-- (Earring) Insomnia Earring
+					15776,	10000,		-- (Ring) Ebullient Ring
+					15777,	10000,		-- (Ring) Hale Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_GEO =
+				{
+					18875,	40000,		-- (Club) Vodun Mace
+					17277,	20000,		-- (Ammunition) Hedgehog Bomb
+					11505,	50000,		-- (Head) Teal Chapeau
+					13778,	50000,		-- (Body) Teal Saio
+					12747,	50000,		-- (Hands) Teal Cuffs
+					14258,	50000,		-- (Legs) Teal Slops
+					11415,	50000,		-- (Feet) Teal Pigaches
+					11807,	50000,		-- (Head) Nebula Hat +1
+					11849,	50000,		-- (Body) Nebula Houppelande +1
+					11916,	50000,		-- (Hands) Nebula Cuffs +1
+					11955,	50000,		-- (Legs) Nebula Slops +1
+					11452,	50000,		-- (Feet) Nebula Pigaches +1
+					11584,	30000,		-- (Neck) Lemegeton Medallion +1
+					11743,	30000,		-- (Waist) Searing Sash
+					11560,	30000,		-- (Back) Pedant Cape
+					11682,	30000,		-- (Earring) Snow Earring
+					13306,	30000,		-- (Ring) Omniscient Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_GEO =
+				{
+					21133,	100000,		-- (Club) Sasah Wand +1
+					21461,	50000,		-- (Handbell) Filiae Bell
+					-- 21362,	30000,		-- (Ammunition) Ombre Tathlum +1
+					27743,	100000,		-- (Head) Temachtiani Headband
+					27884,	100000,		-- (Body) Temachtiani Shirt
+					28032,	100000,		-- (Hands) Temachtiani Gloves
+					28171,	100000,		-- (Legs) Temachtiani Pants
+					28309,	100000,		-- (Feet) Temachtiani Boots
+					-- 25537,	50000,		-- (Neck) Bagua Charm
+					10839,	50000,		-- (Waist) Othila Sash
+					28601,	50000,		-- (Back) Seshaw Cape
+					11682,	30000,		-- (Earring) Snow Earring
+					-- 27574,	50000,		-- (Ring) Shiva Ring
+					4044,   16667,		-- Atramenterrane (Reforged Artifact Material)
+					4043,   16667,		-- Lavarion (Reforged Artifact Material)
+					4042,   16667,		-- Acuex Ore (Reforged Artifact Material)
+					4030,   16667,		-- Sekishitsu (Reforged Artifact Material)
+					4045,   16667,		-- Cyclone Cotton (Reforged Artifact Material)
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_GEO)
+	elseif (job == xi.job.RUN) then
+		local stock_RUN = {}
+		player:PrintToPlayer(string.format("Andreine : Mysterious runes? High magical defenses? 100%% Rune Fencer!"),xi.msg.channel.NS_SAY)
+		
+		if (level <= 30) then
+			stock_RUN =
+				{
+					20781,	5000,		-- (Great Sword) Sowilo Claymore
+					17307,	2,			-- (Ammunition) Dart
+					12695,	2000,		-- (Gloves) Bronze Mittens +1
+					12823,  2000,       -- (Legs) Bronze Subligar +1
+					12951,	2000,		-- (Feet) Bronze Leggings +1
+					13069,	2000,		-- (Neck) Leather Gorget +1
+					13210,	2000,		-- (Waist) Leather Belt +1
+					13599,	2000,		-- (Back) Rabbit Mantle +1
+					14695,	2000,		-- (Earring) Hope Earring +1
+					14694,	2000,		-- (Earring) Energy Earring +1
+					13492,	2000,		-- (Ring) Copper Ring +1
+					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 60) then
+			stock_RUN =
+				{
+					16936,	15000,		-- (Great Sword) Demonic Sword
+					12538,  10000,      -- (Head) Red Cap +1
+					12625,  10000,      -- (Body) Gambison +1
+					12779,  10000,      -- (Hands) Bracers +1
+					12903,  10000,      -- (Legs) Hose +1
+					13034,  10000,      -- (Feet) Socks +1
+					13070,	5000,		-- (Neck) Wolf Gorget +1
+					13223,	5000,		-- (Waist) Silver Belt +1
+					13609,	5000,		-- (Back) Wolf Mantle +1
+					14703,	5000,		-- (Earring) Loyalty Earring +1
+					13519,	5000,		-- (Ring) Mythril Ring +1
+					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
+				}
+		elseif (level <= 75) then
+			stock_RUN =
+				{
+					16616,	25000,		-- (Great Sword) Zweihander +1
+					12120,	50000,		-- (Head) Ebon Mask
+					12156,	50000,		-- (Body) Ebon Harness
+					12192,	50000,		-- (Hands) Ebon Gloves
+					12228,	50000,		-- (Legs) Ebon Brais
+					12264,	50000,		-- (Feet) Ebon Boots
+					15523,	10000,		-- (Neck) Chivalrous Chain
+					15524,	10000,		-- (Neck) Fortified Chain
+					15521,	10000,		-- (Neck) Tempered Chain
+					15884,	10000,		-- (Waist) Potent Belt
+					15493,	10000,		-- (Back) Bushido Cape
+					13369,	10000,		-- (Earring) Spike Earring
+					14764,	10000,		-- (Earring) Minuet Earring
+					13545,	10000,		-- (Ring) Demon's Ring +1
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level < 99) then
+			stock_RUN =
+				{
+					19166,	40000,		-- (Great Sword) Cratus Sword +1
+					16074,	50000,		-- (Head) Hydra Mask +1
+					14538,	50000,		-- (Body) Hydra Mail +1
+					14950,	50000,		-- (Hands) Hydra Finger Gauntlets +1
+					15616,	50000,		-- (Legs) Hydra Cuisses +1
+					15704,	50000,		-- (Feet) Hydra Greaves +1
+					11803,	50000,		-- (Head) Alcide's Cap +1
+					11845,	50000,		-- (Body) Alcide's Harness +1
+					11912,	50000,		-- (Hands) Alcide's Mitts +1
+					11951,	50000,		-- (Legs) Alcide's Subligar +1
+					11448,	50000,		-- (Feet) Alcide's Leggings +1
+					13146,	30000,		-- (Neck) Tern Necklace
+					15922,	30000,		-- (Waist) Tern Stone
+					13619,	30000,		-- (Back) Tern Cape
+					11678,	30000,		-- (Earring) Flame Earring
+					14630,	30000,		-- (Ring) Flame Ring
+					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
+				}
+		elseif (level == 99) then
+			stock_RUN =
+				{
+					20788,	100000,		-- (Great Sword) Hatzoaar Sword +1
+					20786,	100000,		-- (Great Sword) Thurisaz Blade +1
+					10435,	100000,		-- (Head) Dux Visor +1
+					10273,	100000,		-- (Body) Dux Scale Mail +1
+					10317,	100000,		-- (Hands) Dux Finger Gauntlets +1
+					10347,	100000,		-- (Legs) Dux Cuisses +1
+					10364,	100000,		-- (Feet) Dux Greaves +1
+					-- 25543,	50000,		-- (Neck) Futhark Torque
+					10831,	50000,		-- (Waist) Paewr Belt
+					10992,	50000,		-- (Back) Vassal's Mantle
+					11057,	50000,		-- (Earring) Ghillie Earring +1
+					10797,	50000,		-- (Ring) Dagaz Ring
+					10798,	50000,		-- (Ring) Eihwaz Ring
+					4046,   16667,		-- Corroded Ore (Reforged Artifact Material)
+					4025,   16667,		-- Snowsteel Sheet (Reforged Artifact Material)
+					4047,   16667,		-- Redoubtable Silk Thread (Reforged Artifact Material)
+					3923,   16667,		-- Rhodium Ingot (Reforged Artifact Material)
+					4029,   16667,		-- Runeweave (Reforged Artifact Material)
+					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
+				}
+		end
+		
+		xi.shop.general(player, stock_RUN)
+	end
+	player:PrintToPlayer(string.format("Andreine's stock changes when you reach levels 31, 61, 76, and 99."),xi.msg.channel.SYSTEM_3)
+end)
+
+return m

--- a/modules/custom/lua/caldera_npc_module/Andreine.lua
+++ b/modules/custom/lua/caldera_npc_module/Andreine.lua
@@ -16,2682 +16,2682 @@ local m = Module:new("Andreine")
 local npcToReplaceName = "Andreine"
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	local job = player:getMainJob()
-	local level = player:getMainLvl()
-	
-	if (job == xi.job.WAR) then
-		local stock_WAR = {}
-		player:PrintToPlayer(string.format("Andreine : I've got gear to get your Warrior's arsenal started!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then	
-			stock_WAR =
-				{
-					16610,	5000,		-- (Sword) Wax Sword +1
-					16716,	5000,		-- (Great Axe) Butterfly Axe +1
-					16646,	5000,		-- (Axe) Bronze Axe +1
-					17175,	5000,		-- (Archery) Shortbow +1
-					17228,	5000,		-- (Marksmanship) Light Crossbow +1
-					17290,	5000,		-- (Throwing) Coarse Boomerang
-					4219,	200,		-- (Ammunition) Stone Arrow Quiver
-					4227,	200,		-- (Ammunition) Bronze Bolt Quiver
-					12695,	2000,		-- (Gloves) Bronze Mittens +1
-					12823,  2000,       -- (Legs) Bronze Subligar +1
-					12951,	2000,		-- (Feet) Bronze Leggings +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13226,	2000,		-- (Waist) Blood Stone +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_WAR =
-				{
-					16812,  15000,      -- (Sword) War Sword
-					16718,	15000,		-- (Great Axe) Heavy Axe +1
-					16664,	15000,		-- (Axe) War Pick +1
-					17179,	15000,		-- (Archery) Composite Bow +1
-					17229,	15000,		-- (Marksmanship) Zamburak +1
-					4222,	2000,		-- (Ammunition) Horn Arrow Quiver
-					4228,	2000,		-- (Ammunition) Mythril Bolt Quiver
-					12533,  10000,      -- (Head) Silver Mask +1
-					12666,  10000,      -- (Body) Silver Mail +1
-					12772,  10000,      -- (Hands) Silver Mittens +1
-					12894,  10000,      -- (Legs) Silver Hose +1
-					13029,  10000,      -- (Feet) Silver Greaves +1
-					13070,	5000,		-- (Neck) Wolf Gorget +1
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13519,	5000,		-- (Ring) Mythril Ring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_WAR =
-				{
-					16828,  25000,      -- (Sword) Bastard Sword +1
-					16731,	25000,		-- (Great Axe) Colossal Axe +1
-					16682,	25000,		-- (Axe) Darksteel Pick +1
-					17189,	25000,		-- (Archery) Rapid Bow +1
-					17227,	25000,		-- (Marksmanship) Heavy Crossbow +1
-					4224,	5000,		-- (Ammunition) Demon Arrow Quiver
-					4229,	5000,		-- (Ammunition) Darksteel Bolt Quiver
-					15225,	50000,		-- (Head) Fighter's Mask +1
-					14473,	50000,		-- (Body) Fighter's Lorica +1
-					14890,	50000,		-- (Hands) Fighter's Mufflers +1
-					15561,	50000,		-- (Legs) Fighter's Cuisses +1
-					15352,	50000,		-- (Feet) Fighter's Calligae +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13403,	10000,		-- (Earring) Assault Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_WAR =
-				{
-					18512,	40000,		-- (Great Axe) Dolor Bhuj +1
-					16662,	40000,		-- (Axe) Doom Tabar +1
-					18701,	40000,		-- (Archery) Cerberus Bow +1
-					19266,	40000,		-- (Marksmanship) Darkwing +1
-					5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
-					5821,	7500,		-- (Ammunition) Fusion Bolt Quiver
-					11064,	50000,		-- (Head) Ravager's Mask +2
-					11084,	50000,		-- (Body) Ravager's Lorica +2
-					11104,	50000,		-- (Hands) Ravager's Mufflers +2
-					11124,	50000,		-- (Legs) Ravager's Cuisses +2
-					11144,	50000,		-- (Feet) Ravager's Calligae +2
-					11591,  50000,		-- (Neck) Ravager's Gorget
-					11703,  50000,		-- (Earring) Ravager's Earring
-					19253,  50000,		-- (Ammunition) Ravager's Orb
-					10650,	50000,		-- (Head) Warrior's Mask +2
-					10670,	50000,		-- (Body) Warrior's Lorica +2
-					10690,	50000,		-- (Hands) Warrior's Mufflers +2
-					10710,	50000,		-- (Legs) Warrior's Cuisses +2
-					10730,	50000,		-- (Feet) Warrior's Calligae +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11678,	30000,		-- (Earring) Flame Earring
-					14630,	30000,		-- (Ring) Flame Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_WAR =
-				{
-					18916,  300000,		-- (Sword) Heimdall's Doom
-					20879,	100000,		-- (Great Axe) Nohkux Axe +1
-					20832,	65000,		-- (Axe) Aalak' Axe +1
-					19785,	100000,		-- (Archery) Lanner Bow +1
-					19266,	40000,		-- (Marksmanship) Darkwing +1
-					6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
-					6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
-					10442,  300000,		-- (Head) Laeradr Helm
-					10280,  300000,		-- (Body) Laeradr Breastplate
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11064,	50000,		-- (Head) Ravager's Mask +2
-					11084,	50000,		-- (Body) Ravager's Lorica +2
-					11104,	50000,		-- (Hands) Ravager's Mufflers +2
-					11124,	50000,		-- (Legs) Ravager's Cuisses +2
-					11144,	50000,		-- (Feet) Ravager's Calligae +2
-					11591,  50000,		-- (Neck) Ravager's Gorget
-					11703,  50000,		-- (Earring) Ravager's Earring
-					19253,  50000,		-- (Ammunition) Ravager's Orb
-					10650,	50000,		-- (Head) Warrior's Mask +2
-					10670,	50000,		-- (Body) Warrior's Lorica +2
-					10690,	50000,		-- (Hands) Warrior's Mufflers +2
-					10710,	50000,		-- (Legs) Warrior's Cuisses +2
-					10730,	50000,		-- (Feet) Warrior's Calligae +2
-					-- 25417,	50000,		-- (Neck) Warrior's Bead Necklace
-					10831,	50000,		-- (Waist) Paewr Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_WAR)
-	elseif (job == xi.job.MNK) then
-		local stock_MNK = {}
-		player:PrintToPlayer(string.format("Andreine : Ah, the supreme focus of a Monk! I wish I could focus like you..."),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_MNK =
-				{
-					20533,	5000,		-- (Hand-to-Hand) Worm Feelers +1
-					16690,	5000,		-- (Hand-to-Hand) Cesti +1
-					17296,	1,			-- (Throwing) Pebble
-					12695,	2000,		-- (Gloves) Bronze Mittens +1
-					12823,  2000,       -- (Legs) Bronze Subligar +1
-					12951,	2000,		-- (Feet) Bronze Leggings +1
-					13060,	2000,		-- (Neck) Feather Collar +1
-					13184,  5000,       -- (Waist) White Belt
-					13201,  12000,       -- (Waist) Purple Belt
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_MNK =
-				{
-					16445,	15000,		-- (Hand-to-Hand) Claws +1
-					17298,	20,			-- (Ammunition) Tathlum
-					12539,  10000,      -- (Head) Soil Hachimaki +1
-					12671,  10000,      -- (Body) Soil Gi +1
-					12781,  10000,      -- (Hands) Soil Tekko +1
-					12905,  10000,      -- (Legs) Soil Sitabaki +1
-					13035,  10000,      -- (Feet) Soil Kyahan +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13202,	30000,		-- (Waist) Brown Belt
-					13575,	5000,		-- (Back) Ram Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13519,	5000,		-- (Ring) Mythril Ring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_MNK =
-				{
-					18751,  25000,      -- (Hand-to-Hand) Black Adargas +1
-					17299,	50,			-- (Ammunition) Astragalos
-					15226,	50000,		-- (Head) Temple Crown +1
-					14474,	50000,		-- (Body) Temple Cyclas +1
-					14891,	50000,		-- (Hands) Temple Gloves +1
-					15562,	50000,		-- (Legs) Temple Hose +1
-					15353,	50000,		-- (Feet) Temple Gaiters +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					13186,  75000,      -- (Waist) Black Belt
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13369,	10000,		-- (Earring) Spike Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_MNK =
-				{
-					18775,	40000,		-- (Hand-to-Hand) Savate Fists +1
-					19249,	20000,		-- (Ammunition) Thew Bomblet
-					11065,	50000,		-- (Head) Tantra Crown +2
-					11085,	50000,		-- (Body) Tantra Cyclas +2
-					11105,	50000,		-- (Hands) Tantra Gloves +2
-					11125,	50000,		-- (Legs) Tantra Hose +2
-					11145,	50000,		-- (Feet) Tantra Gaiters +2
-					11592,  50000,		-- (Neck) Tantra Necklace
-					11704,  50000,		-- (Earring) Tantra Earring
-					19254,  50000,		-- (Ammunition) Tantra Tathlum
-					10651,	50000,		-- (Head) Melee Crown +2
-					10671,	50000,		-- (Body) Melee Cyclas +2
-					10691,	50000,		-- (Hands) Melee Gloves +2
-					10711,	50000,		-- (Legs) Melee Hose +2
-					10731,	50000,		-- (Feet) Melee Gaiters +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					13186,  75000,      -- (Waist) Black Belt
-					11678,	30000,		-- (Earring) Flame Earring
-					14630,	30000,		-- (Ring) Flame Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_MNK =
-				{
-					20552,	100000,		-- (Hand-to-Hand) Akua Sainti +1
-					19249,	20000,		-- (Ammunition) Thew Bomblet
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11065,	50000,		-- (Head) Tantra Crown +2
-					11085,	50000,		-- (Body) Tantra Cyclas +2
-					11105,	50000,		-- (Hands) Tantra Gloves +2
-					11125,	50000,		-- (Legs) Tantra Hose +2
-					11145,	50000,		-- (Feet) Tantra Gaiters +2
-					11592,  50000,		-- (Neck) Tantra Necklace
-					11704,  50000,		-- (Earring) Tantra Earring
-					19254,  50000,		-- (Ammunition) Tantra Tathlum
-					10651,	50000,		-- (Head) Melee Crown +2
-					10671,	50000,		-- (Body) Melee Cyclas +2
-					10691,	50000,		-- (Hands) Melee Gloves +2
-					10711,	50000,		-- (Legs) Melee Hose +2
-					10731,	50000,		-- (Feet) Melee Gaiters +2
-					-- 25423,	50000,		-- (Neck) Monk's Nodowa
-					13186,  75000,      -- (Waist) Black Belt
-					10831,	50000,		-- (Waist) Paewr Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_MNK)
-	elseif (job == xi.job.WHM) then
-		local stock_WHM = {}
-		player:PrintToPlayer(string.format("Andreine : Hopefully this gear will make leveling White Mage just a little less painful!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_WHM =
-				{
-					17087,	5000,		-- (Club) Maple Wand +1
-					17137,	5000,		-- (Club) Ash Club +1
-					17144,	5000,		-- (Club) Bronze Hammer +1
-					17123,	5000,		-- (Staff) Ash Staff +1
-					17122,	5000,		-- (Staff) Ash Pole +1
-					12744,	2000,		-- (Gloves) Cuffs +1
-					12897,  2000,       -- (Legs) Slops +1
-					12983,	2000,		-- (Feet) Ash Clogs +1
-					13093,	2000,		-- (Neck) Justice Badge
-					13190,	2000,		-- (Waist) Heko Obi +1
-					13605,	2000,		-- (Back) Cape +1
-					14694,	2000,		-- (Earring) Energy Earring +1
-					13440,	2000,		-- (Ring) Ascetic's Ring
-					13548,	50000,		-- (Ring) Astral Ring
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_WHM =
-				{
-					17141,	15000,		-- (Club) Solid Wand
-					17409,	15000,		-- (Club) Mythril Rod +1
-					17121,	15000,		-- (Club) Maul +1
-					17534,	15000,		-- (Staff) Whale Staff +1
-					17119,	15000,		-- (Staff) Elm Pole +1
-					18137,	5000,		-- (Ammunition) Holy Ampulla
-					12538,  10000,      -- (Head) Red Cap +1
-					12625,  10000,      -- (Body) Gambison +1
-					12779,  10000,      -- (Hands) Bracers +1
-					12903,  10000,      -- (Legs) Hose +1
-					13034,  10000,      -- (Feet) Socks +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13233,	5000,		-- (Waist) Gold Obi +1
-					13618,	5000,		-- (Back) White Cape +1
-					14702,	5000,		-- (Earring) Aura Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_WHM =
-				{
-					17427,	25000,		-- (Club) Ebony Wand +1
-					17435,	25000,		-- (Club) Darksteel Rod +1
-					17432,	25000,		-- (Club) Darksteel Maul +1
-					17520,	25000,		-- (Staff) Heavy Staff +1
-					17521,	25000,		-- (Staff) Mahogany Pole +1
-					15227,	50000,		-- (Head) Healer's Cap +1
-					14475,	50000,		-- (Body) Healer's Briault +1
-					14892,	50000,		-- (Hands) Healer's Mitts +1
-					15563,	50000,		-- (Legs) Healer's Pantaloons +1
-					15354,	50000,		-- (Feet) Healer's Duckbills +1
-					15887,	10000,		-- (Neck) Resolute Belt
-					15885,	10000,		-- (Neck) Spectral Belt
-					15490,	10000,		-- (Back) Miraculous Cape
-					15971,	10000,		-- (Earring) Antivenom Earring
-					15972,	10000,		-- (Earring) Insomnia Earring
-					15776,	10000,		-- (Ring) Ebullient Ring
-					15777,	10000,		-- (Ring) Hale Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_WHM =
-				{
-					18874,	40000,		-- (Club) Brise-os +1
-					17568,	40000,		-- (Staff) Eight-sided Pole +1
-					17277,	20000,		-- (Ammunition) Hedgehog Bomb
-					11066,	50000,		-- (Head) Orison Cap +2
-					11086,	50000,		-- (Body) Orison Bliaud +2
-					11106,	50000,		-- (Hands) Orison Mitts +2
-					11126,	50000,		-- (Legs) Orison Pantaloons +2
-					11146,	50000,		-- (Feet) Orison Duckbills +2
-					11615,  50000,		-- (Neck) Orison Locket
-					11705,  50000,		-- (Earring) Orison Earring
-					11554,  50000,		-- (Back) Orison Cape
-					10652,	50000,		-- (Head) Cleric's Cap +2
-					10672,	50000,		-- (Body) Cleric's Briault +2
-					10692,	50000,		-- (Hands) Cleric's Mitts +2
-					10712,	50000,		-- (Legs) Cleric's Pantaloons +2
-					10732,	50000,		-- (Feet) Cleric's Duckbills +2
-					11579,	30000,		-- (Neck) Fylgja Torque
-					15949,	30000,		-- (Waist) Pythia Sash +1
-					27598,	30000,		-- (Back) Dew Silk Cape +1
-					11683,	30000,		-- (Earring) Aqua Earring
-					13308,	30000,		-- (Ring) Communion Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_WHM =
-				{
-					21133,	100000,		-- (Club) Sasah Wand +1
-					21132,	100000,		-- (Club) Aedold
-					21208,	100000,		-- (Staff) Lehbrailg
-					19780,	30000,		-- (Ammunition) Mana Ampulla
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11066,	50000,		-- (Head) Orison Cap +2
-					11086,	50000,		-- (Body) Orison Bliaud +2
-					11106,	50000,		-- (Hands) Orison Mitts +2
-					11126,	50000,		-- (Legs) Orison Pantaloons +2
-					11146,	50000,		-- (Feet) Orison Duckbills +2
-					11615,  50000,		-- (Neck) Orison Locket
-					11705,  50000,		-- (Earring) Orison Earring
-					11554,  50000,		-- (Back) Orison Cape
-					10652,	50000,		-- (Head) Cleric's Cap +2
-					10672,	50000,		-- (Body) Cleric's Briault +2
-					10692,	50000,		-- (Hands) Cleric's Mitts +2
-					10712,	50000,		-- (Legs) Cleric's Pantaloons +2
-					10732,	50000,		-- (Feet) Cleric's Duckbills +2
-					-- 25429,	50000,		-- (Neck) Cleric's Torque
-					28455,	50000,		-- (Waist) Ovate Rope
-					28596,	50000,		-- (Back) Oretania's Cape +1
-					-- 28474,	50000,		-- (Earring) Mendicant's Earring
-					-- 11054,	50000,		-- (Earring) Pensee Earring
-					11683,	30000,		-- (Earring) Aqua Earring
-					-- 27566,	50000,		-- (Ring) Leviathan Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_WHM)
-	elseif (job == xi.job.BLM) then
-		local stock_BLM = {}
-		player:PrintToPlayer(string.format("Andreine : Hmm, do you really need extra gear as a Black Mage? So overpowered!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_BLM =
-				{
-					17087,	5000,		-- (Club) Maple Wand +1
-					17123,	5000,		-- (Staff) Ash Staff +1
-					12744,	2000,		-- (Gloves) Cuffs +1
-					12897,  2000,       -- (Legs) Slops +1
-					12983,	2000,		-- (Feet) Ash Clogs +1
-					13093,	2000,		-- (Neck) Justice Badge
-					13190,	2000,		-- (Waist) Heko Obi +1
-					13605,	2000,		-- (Back) Cape +1
-					14694,	2000,		-- (Earring) Energy Earring +1
-					13475,	2000,		-- (Ring) Hermit's Ring
-					13548,	50000,		-- (Ring) Astral Ring
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_BLM =
-				{
-					17141,	15000,		-- (Club) Solid Wand
-					17409,	15000,		-- (Club) Mythril Rod +1
-					17534,	15000,		-- (Staff) Whale Staff +1
-					17119,	15000,		-- (Staff) Elm Pole +1
-					15173,  10000,      -- (Head) Kosshin
-					13730,  10000,      -- (Body) Frost Robe
-					12750,  10000,      -- (Hands) New Moon Armlets
-					12904,  10000,      -- (Legs) Linen Slacks +1
-					13040,  10000,      -- (Feet) Shoes +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13233,	5000,		-- (Waist) Gold Obi +1
-					13610,	5000,		-- (Back) Black Cape +1
-					14702,	5000,		-- (Earring) Aura Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_BLM =
-				{
-					17427,	25000,		-- (Club) Ebony Wand +1
-					17435,	25000,		-- (Club) Darksteel Rod +1
-					17520,	25000,		-- (Staff) Heavy Staff +1
-					17521,	25000,		-- (Staff) Mahogany Pole +1
-					15228,	50000,		-- (Head) Wizard's Petasos +1
-					14476,	50000,		-- (Body) Wizard's Coat +1
-					14893,	50000,		-- (Hands) Wizard's Gloves +1
-					15564,	50000,		-- (Legs) Wizard's Tonban +1
-					15355,	50000,		-- (Feet) Wizard's Sabots +1
-					15887,	10000,		-- (Neck) Resolute Belt
-					15885,	10000,		-- (Neck) Spectral Belt
-					15490,	10000,		-- (Back) Miraculous Cape
-					15971,	10000,		-- (Earring) Antivenom Earring
-					15972,	10000,		-- (Earring) Insomnia Earring
-					15776,	10000,		-- (Ring) Ebullient Ring
-					15777,	10000,		-- (Ring) Hale Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_BLM =
-				{
-					17118,	40000,		-- (Staff) Lituus +1
-					17277,	20000,		-- (Ammunition) Hedgehog Bomb
-					11067,	50000,		-- (Head) Goetia Petasos +2
-					11087,	50000,		-- (Body) Goetia Coat +2
-					11107,	50000,		-- (Hands) Goetia Gloves +2
-					11127,	50000,		-- (Legs) Goetia Chausses +2
-					11147,	50000,		-- (Feet) Goetia Sabots +2
-					11593,  50000,		-- (Neck) Goetia Chain
-					11706,  50000,		-- (Earring) Goetia Earring
-					16203,  50000,		-- (Back) Goetia Mantle
-					10653,	50000,		-- (Head) Sorcerer's Petasos +2
-					10673,	50000,		-- (Body) Sorcerer's Coat +2
-					10693,	50000,		-- (Hands) Sorcerer's Gloves +2
-					10713,	50000,		-- (Legs) Sorcerer's Tonban +2
-					10733,	50000,		-- (Feet) Sorcerer's Sabots +2
-					11584,	30000,		-- (Neck) Lemegeton Medallion +1
-					11743,	30000,		-- (Waist) Searing Sash
-					11560,	30000,		-- (Back) Pedant Cape
-					11682,	30000,		-- (Earring) Snow Earring
-					13306,	30000,		-- (Ring) Omniscient Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_BLM =
-				{
-					21133,	100000,		-- (Club) Sasah Wand +1
-					21208,	100000,		-- (Staff) Lehbrailg
-					-- 21362,	30000,		-- (Ammunition) Ombre Tathlum +1
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11067,	50000,		-- (Head) Goetia Petasos +2
-					11087,	50000,		-- (Body) Goetia Coat +2
-					11107,	50000,		-- (Hands) Goetia Gloves +2
-					11127,	50000,		-- (Legs) Goetia Chausses +2
-					11147,	50000,		-- (Feet) Goetia Sabots +2
-					11593,  50000,		-- (Neck) Goetia Chain
-					11706,  50000,		-- (Earring) Goetia Earring
-					16203,  50000,		-- (Back) Goetia Mantle
-					10653,	50000,		-- (Head) Sorcerer's Petasos +2
-					10673,	50000,		-- (Body) Sorcerer's Coat +2
-					10693,	50000,		-- (Hands) Sorcerer's Gloves +2
-					10713,	50000,		-- (Legs) Sorcerer's Tonban +2
-					10733,	50000,		-- (Feet) Sorcerer's Sabots +2
-					-- 25435,	50000,		-- (Neck) Sorcerer's Stole
-					10839,	50000,		-- (Waist) Othila Sash
-					28601,	50000,		-- (Back) Seshaw Cape
-					11682,	30000,		-- (Earring) Snow Earring
-					-- 27574,	50000,		-- (Ring) Shiva Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_BLM)
-	elseif (job == xi.job.RDM) then
-		local stock_RDM = {}
-		player:PrintToPlayer(string.format("Andreine : Couldn't pick just one school of magic to focus on eh? That's ok, I've got gear for you!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_RDM =
-				{
-					16610,	5000,		-- (Sword) Wax Sword +1
-					17087,	5000,		-- (Club) Maple Wand +1
-					12744,	2000,		-- (Gloves) Cuffs +1
-					12897,  2000,       -- (Legs) Slops +1
-					12983,	2000,		-- (Feet) Ash Clogs +1
-					13093,	2000,		-- (Neck) Justice Badge
-					13190,	2000,		-- (Waist) Heko Obi +1
-					13605,	2000,		-- (Back) Cape +1
-					14694,	2000,		-- (Earring) Energy Earring +1
-					13440,	2000,		-- (Ring) Ascetic's Ring
-					13475,	2000,		-- (Ring) Hermit's Ring
-					13548,	50000,		-- (Ring) Astral Ring
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_RDM =
-				{
-					16815,  15000,      -- (Sword) Mythril Degen +1
-					12335,  10000,      -- (Shield) Targe +1
-					17141,	15000,		-- (Club) Solid Wand
-					17534,	15000,		-- (Staff) Whale Staff +1
-					12538,  10000,      -- (Head) Red Cap +1
-					12625,  10000,      -- (Body) Gambison +1
-					12779,  10000,      -- (Hands) Bracers +1
-					12903,  10000,      -- (Legs) Hose +1
-					13034,  10000,      -- (Feet) Socks +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13233,	5000,		-- (Waist) Gold Obi +1
-					13611,	7500,		-- (Back) Red Cape +1
-					14702,	5000,		-- (Earring) Aura Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_RDM =
-				{
-					17641,  25000,      -- (Sword) Gold Sword +1
-					12353,  25000,      -- (Shield) Gilt Buckler
-					17427,	25000,		-- (Club) Ebony Wand +1
-					17520,	25000,		-- (Staff) Heavy Staff +1
-					15229,	50000,		-- (Head) Warlock's Chapeau +1
-					14477,	50000,		-- (Body) Warlock's Tabard +1
-					14894,	50000,		-- (Hands) Warlock's Gloves +1
-					15565,	50000,		-- (Legs) Warlock's Tights +1
-					15356,	50000,		-- (Feet) Warlock's Boots +1
-					15887,	10000,		-- (Neck) Resolute Belt
-					15885,	10000,		-- (Neck) Spectral Belt
-					15490,	10000,		-- (Back) Miraculous Cape
-					15971,	10000,		-- (Earring) Antivenom Earring
-					15972,	10000,		-- (Earring) Insomnia Earring
-					15776,	10000,		-- (Ring) Ebullient Ring
-					15777,	10000,		-- (Ring) Hale Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_RDM =
-				{
-					17664,  40000,      -- (Sword) Firmament +1
-					12386,  40000,      -- (Shield) Acheron Shield +1
-					17277,	20000,		-- (Ammunition) Hedgehog Bomb
-					11068,	50000,		-- (Head) Estoqueur's Chappel +2
-					11088,	50000,		-- (Body) Estoqueur's Sayon +2
-					11108,	50000,		-- (Hands) Estoqueur's Gantherots +2
-					11128,	50000,		-- (Legs) Estoqueur's Fuseau +2
-					11148,	50000,		-- (Feet) Estoqueur's Houseaux +2
-					11594,  50000,		-- (Neck) Estoqueur's Collar
-					11707,  50000,		-- (Earring) Estoqueur's Earring
-					16204,  50000,		-- (Back) Estoqueur's Cape
-					10654,	50000,		-- (Head) Duelist's Chapeau +2
-					10674,	50000,		-- (Body) Duelist's Tabard +2
-					10694,	50000,		-- (Hands) Duelist's Gloves +2
-					10714,	50000,		-- (Legs) Duelist's Tights +2
-					10734,	50000,		-- (Feet) Duelist's Boots +2
-					11579,	30000,		-- (Neck) Fylgja Torque
-					11584,	30000,		-- (Neck) Lemegeton Medallion +1
-					11747,	30000,		-- (Waist) Austerity Belt
-					16210,	30000,		-- (Back) Ebullient Cape
-					16052,	30000,		-- (Earring) Incubus Earring
-					11683,	30000,		-- (Earring) Aqua Earring
-					11682,	30000,		-- (Earring) Snow Earring
-					13308,	30000,		-- (Ring) Communion Ring
-					13306,	30000,		-- (Ring) Omniscient Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_RDM =
-				{
-					20743,	100000,		-- (Sword) Bihkah Sword +1
-					28668,  100000,     -- (Shield) Matamata Shield +1
-					21207,	100000,		-- (Staff) Hemolele Staff +1
-					-- 21362,	30000,		-- (Ammunition) Ombre Tathlum +1
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11068,	50000,		-- (Head) Estoqueur's Chappel +2
-					11088,	50000,		-- (Body) Estoqueur's Sayon +2
-					11108,	50000,		-- (Hands) Estoqueur's Gantherots +2
-					11128,	50000,		-- (Legs) Estoqueur's Fuseau +2
-					11148,	50000,		-- (Feet) Estoqueur's Houseaux +2
-					11594,  50000,		-- (Neck) Estoqueur's Collar
-					11707,  50000,		-- (Earring) Estoqueur's Earring
-					16204,  50000,		-- (Back) Estoqueur's Cape
-					10654,	50000,		-- (Head) Duelist's Chapeau +2
-					10674,	50000,		-- (Body) Duelist's Tabard +2
-					10694,	50000,		-- (Hands) Duelist's Gloves +2
-					10714,	50000,		-- (Legs) Duelist's Tights +2
-					10734,	50000,		-- (Feet) Duelist's Boots +2
-					-- 25441,	50000,		-- (Neck) Duelist's Torque
-					10839,	50000,		-- (Waist) Othila Sash
-					28455,	50000,		-- (Waist) Ovate Rope
-					28596,	50000,		-- (Back) Oretania's Cape +1
-					28601,	50000,		-- (Back) Seshaw Cape
-					11683,	30000,		-- (Earring) Aqua Earring
-					11682,	30000,		-- (Earring) Snow Earring
-					-- 27566,	50000,		-- (Ring) Leviathan Ring
-					-- 27574,	50000,		-- (Ring) Shiva Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_RDM)
-	elseif (job == xi.job.THF) then
-		local stock_THF = {}
-		player:PrintToPlayer(string.format("Andreine : Please keep in mind that my wares are for sale and not lifting by sticky fingers!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_THF =
-				{
-					16610,	5000,		-- (Sword) Wax Sword +1
-					16690,	5000,		-- (Hand-to-Hand) Cesti +1
-					16491,	5000,		-- (Dagger) Bronze Knife +1
-					16492,	5000,		-- (Dagger) Bronze Dagger +1
-					17175,	5000,		-- (Archery) Shortbow +1
-					19225,	5000,		-- (Marksmanship) Musketoon +1
-					17290,	5000,		-- (Throwing) Coarse Boomerang
-					4219,	200,		-- (Ammunition) Stone Arrow Quiver
-					5359,	200,		-- (Ammunition) Bronze Bullet Pouch
-					12695,	2000,		-- (Gloves) Bronze Mittens +1
-					12823,  2000,       -- (Legs) Bronze Subligar +1
-					12951,	2000,		-- (Feet) Bronze Leggings +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_THF =
-				{
-					19106,	10000,      -- (Dagger) Thug's Jambiya +1
-					17260,	15000,		-- (Marksmanship) Pirate's Gun +1
-					5363,	2000,		-- (Ammunition) Bullet Pouch
-					12538,  10000,      -- (Head) Red Cap +1
-					12625,  10000,      -- (Body) Gambison +1
-					12779,  10000,      -- (Hands) Bracers +1
-					12903,  10000,      -- (Legs) Hose +1
-					13034,  10000,      -- (Feet) Socks +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_THF =
-				{
-					17603,  15000,      -- (Dagger) Cermet Kukri +1
-					19227,	25000,		-- (Marksmanship) Blunderbuss +1
-					5353,	5000,		-- (Ammunition) Iron Bullet Pouch
-					15230,	50000,		-- (Head) Rogue's Bonnet +1
-					14478,	50000,		-- (Body) Rogue's Vest +1
-					14895,	50000,		-- (Hands) Rogue's Armlets +1
-					15566,	50000,		-- (Legs) Rogue's Culottes +1
-					15357,	50000,		-- (Feet) Rogue's Poulaines +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13369,	10000,		-- (Earring) Spike Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_THF =
-				{
-					16481,  35000,      -- (Dagger) Yataghan +1
-					17252,	40000,		-- (Marksmanship) Culverin
-					5353,	5000,		-- (Ammunition) Iron Bullet Pouch
-					17342,	75,			-- (Ammunition) Cannon Shell
-					11069,	50000,		-- (Head) Raider's Bonnet +2
-					11089,	50000,		-- (Body) Raider's Vest +2
-					11109,	50000,		-- (Hands) Raider's Armlets +2
-					11129,	50000,		-- (Legs) Raider's Culottes +2
-					11149,	50000,		-- (Feet) Raider's Poulaines +2 (TH)
-					19260,  50000,		-- (Throwing) Raider's Boomerang
-					11708,  50000,		-- (Earring) Raider's Earring
-					11736,  50000,		-- (Waist) Raider's Belt
-					10655,	50000,		-- (Head) Assassin's Bonnet +2
-					10675,	50000,		-- (Body) Assassin's Vest +2
-					10695,	50000,		-- (Hands) Assassin's Armlets +2 (TH)
-					10715,	50000,		-- (Legs) Assassin's Culottes +2
-					10735,	50000,		-- (Feet) Assassin's Poulaines +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11681,	30000,		-- (Earring) Breeze Earring
-					11679,	30000,		-- (Earring) Thunder Earring
-					14636,	30000,		-- (Ring) Breeze Ring
-					14638,	30000,		-- (Ring) Thunder Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_THF =
-				{
-					20642,	65000,		-- (Dagger) Tzustes Knife +1
-					19742,  100000,     -- (Marksmanship) Handgonne +1
-					5353,	5000,		-- (Ammunition) Iron Bullet Pouch
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11069,	50000,		-- (Head) Raider's Bonnet +2
-					11089,	50000,		-- (Body) Raider's Vest +2
-					11109,	50000,		-- (Hands) Raider's Armlets +2
-					11129,	50000,		-- (Legs) Raider's Culottes +2
-					11149,	50000,		-- (Feet) Raider's Poulaines +2 (TH)
-					19260,  50000,		-- (Throwing) Raider's Boomerang
-					11708,  50000,		-- (Earring) Raider's Earring
-					11736,  50000,		-- (Waist) Raider's Belt
-					10655,	50000,		-- (Head) Assassin's Bonnet +2
-					10675,	50000,		-- (Body) Assassin's Vest +2
-					10695,	50000,		-- (Hands) Assassin's Armlets +2 (TH)
-					10715,	50000,		-- (Legs) Assassin's Culottes +2
-					10735,	50000,		-- (Feet) Assassin's Poulaines +2
-					-- 25447,	50000,		-- (Neck) Assassin's Gorget
-					10831,	50000,		-- (Waist) Paewr Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_THF)
-	elseif (job == xi.job.PLD) then
-		local stock_PLD = {}
-		player:PrintToPlayer(string.format("Andreine : You're going to need to soak up a lot of damage as a Paladin! I hope this gear helps!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_PLD =
-				{
-					16627,	5000,		-- (Sword) Spatha +1
-					12371,	5000,		-- (Shield) Clipeus
-					17175,	5000,		-- (Archery) Shortbow +1
-					4219,	200,		-- (Ammunition) Stone Arrow Quiver
-					12784,	2000,		-- (Gloves) Leather Gloves +1
-					12908,  2000,       -- (Legs) Leather Trousers +1
-					12971,	2000,		-- (Feet) Leather Highboots +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					14670,	2000,		-- (Ring) Safeguard Ring
-					13548,	50000,		-- (Ring) Astral Ring
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_PLD =
-				{
-					16812,  15000,      -- (Sword) War Sword
-					12335,  10000,      -- (Shield) Targe +1
-					17179,	15000,		-- (Archery) Composite Bow +1
-					4222,	2000,		-- (Ammunition) Horn Arrow Quiver
-					12533,  10000,      -- (Head) Silver Mask +1
-					12666,  10000,      -- (Body) Silver Mail +1
-					12772,  10000,      -- (Hands) Silver Mittens +1
-					12894,  10000,      -- (Legs) Silver Hose +1
-					13029,  10000,      -- (Feet) Silver Greaves +1
-					13070,	5000,		-- (Neck) Wolf Gorget +1
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13506,	5000,		-- (Ring) Bomb Ring
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_PLD =
-				{
-					17641,  25000,      -- (Sword) Gold Sword +1
-					12353,  25000,      -- (Shield) Gilt Buckler
-					17189,	25000,		-- (Archery) Rapid Bow +1
-					4224,	5000,		-- (Ammunition) Demon Arrow Quiver
-					15231,	50000,		-- (Head) Gallant Coronet +1
-					14479,	50000,		-- (Body) Gallant Surcoat +1
-					14896,	50000,		-- (Hands) Gallant Gauntlets +1
-					15567,	50000,		-- (Legs) Gallant Breeches +1
-					15358,	50000,		-- (Feet) Gallant Leggings +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15887,	10000,		-- (Waist) Resolute Belt
-					13691,	10000,		-- (Back) Knightly Mantle
-					14758,	10000,		-- (Earring) Knightly Earring
-					16009,	10000,		-- (Earring) Pennon Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_PLD =
-				{
-					17664,  40000,      -- (Sword) Firmament +1
-					16163,  40000,      -- (Shield) Januwiyah +1
-					18682,	40000,		-- (Archery) Lamian Kaman +1
-					5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
-					11070,	50000,		-- (Head) Creed Armet +2
-					11090,	50000,		-- (Body) Creed Cuirass +2
-					11110,	50000,		-- (Hands) Creed Gauntlets +2
-					11130,	50000,		-- (Legs) Creed Cuisses +2
-					11150,	50000,		-- (Feet) Creed Sabatons +2
-					11595,  50000,		-- (Neck) Creed Collar
-					11709,  50000,		-- (Earring) Creed Earring
-					11750,  50000,		-- (Waist) Creed Baudrier
-					10656,	50000,		-- (Head) Valor Coronet +2
-					10676,	50000,		-- (Body) Valor Surcoat +2
-					10696,	50000,		-- (Hands) Valor Gauntlets +2
-					10716,	50000,		-- (Legs) Valor Breeches +2
-					10736,	50000,		-- (Feet) Valor Leggings +2
-					10929,	30000,		-- (Neck) Apathy Gorget
-					15895,	30000,		-- (Waist) Trance Belt (AH price)
-					16216,	30000,		-- (Back) Cerberus Mantle +1
-					11680,	30000,		-- (Earring) Soil Earring
-					14634,	30000,		-- (Ring) Soil Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_PLD =
-				{
-					20743,	100000,		-- (Sword) Bihkah Sword +1
-					28668,  100000,     -- (Shield) Matamata Shield +1
-					19785,	100000,		-- (Archery) Lanner Bow +1
-					6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
-					10442,  300000,		-- (Head) Laeradr Helm
-					10280,  300000,		-- (Body) Laeradr Breastplate
-					10435,	100000,		-- (Head) Dux Visor +1
-					10273,	100000,		-- (Body) Dux Scale Mail +1
-					10317,	100000,		-- (Hands) Dux Finger Gauntlets +1
-					10347,	100000,		-- (Legs) Dux Cuisses +1
-					10364,	100000,		-- (Feet) Dux Greaves +1
-					11070,	50000,		-- (Head) Creed Armet +2
-					11090,	50000,		-- (Body) Creed Cuirass +2
-					11110,	50000,		-- (Hands) Creed Gauntlets +2
-					11130,	50000,		-- (Legs) Creed Cuisses +2
-					11150,	50000,		-- (Feet) Creed Sabatons +2
-					11595,  50000,		-- (Neck) Creed Collar
-					11709,  50000,		-- (Earring) Creed Earring
-					11750,  50000,		-- (Waist) Creed Baudrier
-					10656,	50000,		-- (Head) Valor Coronet +2
-					10676,	50000,		-- (Body) Valor Surcoat +2
-					10696,	50000,		-- (Hands) Valor Gauntlets +2
-					10716,	50000,		-- (Legs) Valor Breeches +2
-					10736,	50000,		-- (Feet) Valor Leggings +2
-					-- 25453,	50000,		-- (Neck) Knight's Bead Necklace
-					10819,	50000,		-- (Waist) Flume Belt
-					10996,	50000,		-- (Back) Testudo Mantle
-					11050,	50000,		-- (Earring) Puissant Pearl
-					11039,	50000,		-- (Earring) Brachyura Earring
-					10798,	50000,		-- (Ring) Eihwaz Ring
-					28577,	50000,		-- (Ring) Kunaji Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_PLD)
-	elseif (job == xi.job.DRK) then
-		local stock_DRK = {}
-		player:PrintToPlayer(string.format("Andreine : I know you're always hungry for more souls as a Dark Knight but don't forget to eat food too!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_DRK =
-				{
-					16778,	5000,		-- (Scythe) Bronze Zaghnal +1
-					16606,	5000,		-- (Great Sword) Rusty Greatsword
-					16637,	5000,		-- (Great Sword) Deathbringer
-					16716,	5000,		-- (Great Axe) Butterfly Axe +1
-					17228,	5000,		-- (Marksmanship) Light Crossbow +1
-					4227,	200,		-- (Ammunition) Bronze Bolt Quiver
-					12784,	2000,		-- (Gloves) Leather Gloves +1
-					12908,  2000,       -- (Legs) Leather Trousers +1
-					12971,	2000,		-- (Feet) Leather Highboots +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_DRK =
-				{
-					16797,  15000,      -- (Scythe) Mythril Zaghnal +1
-					16936,	15000,		-- (Great Sword) Demonic Sword
-					17229,	15000,		-- (Marksmanship) Zamburak +1
-					4228,	2000,		-- (Ammunition) Mythril Bolt Quiver
-					12533,  10000,      -- (Head) Silver Mask +1
-					12666,  10000,      -- (Body) Silver Mail +1
-					12772,  10000,      -- (Hands) Silver Mittens +1
-					12894,  10000,      -- (Legs) Silver Hose +1
-					13029,  10000,      -- (Feet) Silver Greaves +1
-					13070,	5000,		-- (Neck) Wolf Gorget +1
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13519,	5000,		-- (Ring) Mythril Ring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_DRK =
-				{
-					16790,  25000,      -- (Scythe) Darksteel Scythe +1
-					16616,	25000,		-- (Great Sword) Zweihander +1
-					17227,	25000,		-- (Marksmanship) Heavy Crossbow +1
-					4229,	5000,		-- (Ammunition) Darksteel Bolt Quiver
-					15232,	50000,		-- (Head) Chaos Burgeonet +1
-					14480,	50000,		-- (Body) Chaos Cuirass +1
-					14897,	50000,		-- (Hands) Chaos Gauntlets +1
-					15568,	50000,		-- (Legs) Chaos Flanchard +1
-					15359,	50000,		-- (Feet) Chaos Sollerets +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13403,	10000,		-- (Earring) Assault Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_DRK =
-				{
-					18965,	40000,		-- (Scythe) Dire Scythe +1
-					19166,	40000,		-- (Great Sword) Cratus Sword +1
-					19266,	40000,		-- (Marksmanship) Darkwing +1
-					5821,	7500,		-- (Ammunition) Fusion Bolt Quiver
-					11071,	50000,		-- (Head) Bale Burgeonet +2
-					11091,	50000,		-- (Body) Bale Cuirass +2
-					11111,	50000,		-- (Hands) Bale Gauntlets +2
-					11131,	50000,		-- (Legs) Bale Flanchard +2
-					11151,	50000,		-- (Feet) Bale Sollerets +2
-					11616,  50000,		-- (Neck) Bale Choker
-					11710,  50000,		-- (Earring) Bale Earring
-					11737,  50000,		-- (Waist) Bale Belt
-					10657,	50000,		-- (Head) Abyss Burgeonet +2
-					10677,	50000,		-- (Body) Abyss Cuirass +2
-					10697,	50000,		-- (Hands) Abyss Gauntlets +2
-					10717,	50000,		-- (Legs) Abyss Flanchard +2
-					10737,	50000,		-- (Feet) Abyss Sollerets +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11678,	30000,		-- (Earring) Flame Earring
-					14630,	30000,		-- (Ring) Flame Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_DRK =
-				{
-					18916,  300000,		-- (Sword) Heimdall's Doom
-					20923,	100000,		-- (Scythe) Aak'ab Scythe +1
-					20788,	100000,		-- (Great Sword) Hatzoaar Sword +1
-					19266,	40000,		-- (Marksmanship) Darkwing +1
-					6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
-					10442,  300000,		-- (Head) Laeradr Helm
-					10280,  300000,		-- (Body) Laeradr Breastplate
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11071,	50000,		-- (Head) Bale Burgeonet +2
-					11091,	50000,		-- (Body) Bale Cuirass +2
-					11111,	50000,		-- (Hands) Bale Gauntlets +2
-					11131,	50000,		-- (Legs) Bale Flanchard +2
-					11151,	50000,		-- (Feet) Bale Sollerets +2
-					11616,  50000,		-- (Neck) Bale Choker
-					11710,  50000,		-- (Earring) Bale Earring
-					11737,  50000,		-- (Waist) Bale Belt
-					10657,	50000,		-- (Head) Abyss Burgeonet +2
-					10677,	50000,		-- (Body) Abyss Cuirass +2
-					10697,	50000,		-- (Hands) Abyss Gauntlets +2
-					10717,	50000,		-- (Legs) Abyss Flanchard +2
-					10737,	50000,		-- (Feet) Abyss Sollerets +2
-					-- 25459,	50000,		-- (Neck) Abyssal Bead Necklace
-					10831,	50000,		-- (Waist) Paewr Belt
-					10819,	50000,		-- (Waist) Flume Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_DRK)
-	elseif (job == xi.job.BST) then
-		local stock_BST = {}
-		player:PrintToPlayer(string.format("Andreine : You're lucky to always have a friend as a Beastmaster! I miss my pets..."),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_BST =
-				{
-					16646,	5000,		-- (Axe) Bronze Axe +1
-					16778,	5000,		-- (Scythe) Bronze Zaghnal +1
-					12695,	2000,		-- (Gloves) Bronze Mittens +1
-					12823,  2000,       -- (Legs) Bronze Subligar +1
-					12951,	2000,		-- (Feet) Bronze Leggings +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13072,	2000,		-- (Neck) Bird Whistle
-					13110,	2000,		-- (Neck) Beast Whistle
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_BST =
-				{
-					16664,	15000,		-- (Axe) War Pick +1
-					12335,  10000,      -- (Shield) Targe +1
-					16797,  15000,      -- (Scythe) Mythril Zaghnal +1
-					12533,  10000,      -- (Head) Silver Mask +1
-					12666,  10000,      -- (Body) Silver Mail +1
-					12772,  10000,      -- (Hands) Silver Mittens +1
-					12894,  10000,      -- (Legs) Silver Hose +1
-					13029,  10000,      -- (Feet) Silver Greaves +1
-					13070,	5000,		-- (Neck) Wolf Gorget +1
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13519,	5000,		-- (Ring) Mythril Ring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_BST =
-				{
-					16682,	25000,		-- (Axe) Darksteel Pick +1
-					12353,  25000,      -- (Shield) Gilt Buckler
-					18962,  25000,      -- (Scythe) Rusty Zaghnal
-					15233,	50000,		-- (Head) Beast Helm +1
-					14481,	50000,		-- (Body) Beast Jackcoat +1
-					14898,	50000,		-- (Hands) Beast Gloves +1
-					15569,	50000,		-- (Legs) Beast Trousers +1
-					15360,	50000,		-- (Feet) Beast Gaiters +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13403,	10000,		-- (Earring) Assault Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_BST =
-				{
-					16662,	40000,		-- (Axe) Doom Tabar +1
-					12386,  40000,      -- (Shield) Acheron Shield +1
-					18963,	40000,		-- (Scythe) Gleaming Zaghnal
-					11072,	50000,		-- (Head) Ferine Cabasset +2
-					11092,	50000,		-- (Body) Ferine Gausape +2
-					11112,	50000,		-- (Hands) Ferine Manoplas +2
-					11132,	50000,		-- (Legs) Ferine Quijotes +2
-					11152,	50000,		-- (Feet) Ferine Ocreae +2
-					11617,  50000,		-- (Neck) Ferine Necklace
-					11711,  50000,		-- (Earring) Ferine Earring
-					11555,  50000,		-- (Back) Ferine Mantle
-					10658,	50000,		-- (Head) Monster Helm +2
-					10678,	50000,		-- (Body) Monster Jackcoat +2
-					10698,	50000,		-- (Hands) Monster Gloves +2
-					10718,	50000,		-- (Legs) Monster Trousers +2
-					10738,	50000,		-- (Feet) Monster Gaiters +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11678,	30000,		-- (Earring) Flame Earring
-					14630,	30000,		-- (Ring) Flame Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_BST =
-				{
-					20832,	65000,		-- (Axe) Aalak' Axe +1
-					28668,  100000,     -- (Shield) Matamata Shield +1
-					18562,	100000,		-- (Scythe) Yhatdhara +1
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11072,	50000,		-- (Head) Ferine Cabasset +2
-					11092,	50000,		-- (Body) Ferine Gausape +2
-					11112,	50000,		-- (Hands) Ferine Manoplas +2
-					11132,	50000,		-- (Legs) Ferine Quijotes +2
-					11152,	50000,		-- (Feet) Ferine Ocreae +2
-					11617,  50000,		-- (Neck) Ferine Necklace
-					11711,  50000,		-- (Earring) Ferine Earring
-					11555,  50000,		-- (Back) Ferine Mantle
-					10658,	50000,		-- (Head) Monster Helm +2
-					10678,	50000,		-- (Body) Monster Jackcoat +2
-					10698,	50000,		-- (Hands) Monster Gloves +2
-					10718,	50000,		-- (Legs) Monster Trousers +2
-					10738,	50000,		-- (Feet) Monster Gaiters +2
-					-- 25465,	50000,		-- (Neck) Beastmaster Collar
-					10831,	50000,		-- (Waist) Paewr Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_BST)
-	elseif (job == xi.job.BRD) then
-		local stock_BRD = {}
-		player:PrintToPlayer(string.format("Andreine : Your audiences will expect only the finest from their Bard!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_BRD =
-				{
-					16610,	5000,		-- (Sword) Wax Sword +1
-					16491,	5000,		-- (Dagger) Bronze Knife +1
-					16492,	5000,		-- (Dagger) Bronze Dagger +1
-					17372,	5000,		-- (Wind Instrument) Flute +1
-					17373,	5000,		-- (String Instrument) Maple Harp +1
-					12744,	2000,		-- (Gloves) Cuffs +1
-					12897,  2000,       -- (Legs) Slops +1
-					12983,	2000,		-- (Feet) Ash Clogs +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13072,	2000,		-- (Neck) Bird Whistle
-					13190,	2000,		-- (Waist) Heko Obi +1
-					13605,	2000,		-- (Back) Cape +1
-					14694,	2000,		-- (Earring) Energy Earring +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					13548,	50000,		-- (Ring) Astral Ring
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_BRD =
-				{
-					16815,	15000,      -- (Sword) Mythril Degen +1
-					17375,	10000,		-- (Wind Instrument) Traversiere +1
-					17376,	10000,		-- (String Instrument) Rose Harp +1
-					12538,  10000,      -- (Head) Red Cap +1
-					12625,  10000,      -- (Body) Gambison +1
-					12779,  10000,      -- (Hands) Bracers +1
-					12903,  10000,      -- (Legs) Hose +1
-					13034,  10000,      -- (Feet) Socks +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_BRD =
-				{
-					16618,  25000,      -- (Sword) Mailbreaker +1
-					17832,	15000,		-- (Wind Instrument) Shofar +1
-					17833,	15000,		-- (String Instrument) Ebony Harp +1
-					15234,	50000,		-- (Head) Choral Roundlet +1
-					14482,	50000,		-- (Body) Choral Justaucorps +1
-					14899,	50000,		-- (Hands) Choral Cuffs +1
-					15570,	50000,		-- (Legs) Choral Cannions +1
-					15361,	50000,		-- (Feet) Choral Slippers +1
-					15524,	10000,		-- (Neck) Fortified Chain
-					15525,	10000,		-- (Neck) Grandiose Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15887,	10000,		-- (Neck) Resolute Belt
-					15490,	10000,		-- (Back) Miraculous Cape
-					16009,	10000,		-- (Earring) Pennon Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_BRD =
-				{
-					17719,  40000,      -- (Sword) Mensur Epee
-					11073,	50000,		-- (Head) Aoidos' Calot +2
-					11093,	50000,		-- (Body) Aoidos' Hongreline +2
-					11113,	50000,		-- (Hands) Aoidos' Manchettes +2
-					11133,	50000,		-- (Legs) Aoidos' Rhingrave +2
-					11153,	50000,		-- (Feet) Aoidos' Cothurnes +2
-					11618,  50000,		-- (Neck) Aoidos' Matinee
-					11712,  50000,		-- (Earring) Aoidos' Earring
-					11738,  50000,		-- (Waist) Aoidos' Belt
-					10659,	50000,		-- (Head) Bard's Roundlet +2
-					10679,	50000,		-- (Body) Bard's Justaucorps +2
-					10699,	50000,		-- (Hands) Bard's Cuffs +2
-					10719,	50000,		-- (Legs) Bard's Cannions +2
-					10739,	50000,		-- (Feet) Bard's Slippers +2
-					11608,	30000,		-- (Neck) Barcarolle Medal
-					11745,	30000,		-- (Waist) Aristo Belt
-					11563,	30000,		-- (Back) Mesmeric Cape
-					11724,	30000,		-- (Earring) Reverie Earring +1
-					14643,	30000,		-- (Ring) Apollo's Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_BRD =
-				{
-					20743,	100000,		-- (Sword) Bihkah Sword +1
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11073,	50000,		-- (Head) Aoidos' Calot +2
-					11093,	50000,		-- (Body) Aoidos' Hongreline +2
-					11113,	50000,		-- (Hands) Aoidos' Manchettes +2
-					11133,	50000,		-- (Legs) Aoidos' Rhingrave +2
-					11153,	50000,		-- (Feet) Aoidos' Cothurnes +2
-					11618,  50000,		-- (Neck) Aoidos' Matinee
-					11712,  50000,		-- (Earring) Aoidos' Earring
-					11738,  50000,		-- (Waist) Aoidos' Belt
-					10659,	50000,		-- (Head) Bard's Roundlet +2
-					10679,	50000,		-- (Body) Bard's Justaucorps +2
-					10699,	50000,		-- (Hands) Bard's Cuffs +2
-					10719,	50000,		-- (Legs) Bard's Cannions +2
-					10739,	50000,		-- (Feet) Bard's Slippers +2
-					-- 25471,	50000,		-- (Neck) Bard's Charm
-					10826,	50000,		-- (Waist) Witful Belt
-					11012,	50000,		-- (Back) Gwyddion's Cape
-					11036,	50000,		-- (Earring) Enchanter's Earring
-					11701,	50000,		-- (Earring) Skald Breloque
-					-- 27576,	50000,		-- (Ring) Carbuncle Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_BRD)
-	elseif (job == xi.job.RNG) then
-		local stock_RNG = {}
-		player:PrintToPlayer(string.format("Andreine : I had no idea there were so many types of ranged weapons! How do you Rangers choose?"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_RNG =
-				{
-					16610,	5000,		-- (Sword) Wax Sword +1
-					16491,	5000,		-- (Dagger) Bronze Knife +1
-					16492,	5000,		-- (Dagger) Bronze Dagger +1
-					17175,	5000,		-- (Archery) Shortbow +1
-					17177,	5000,		-- (Archery) Longbow +1
-					17228,	5000,		-- (Marksmanship) Light Crossbow +1
-					19225,	5000,		-- (Marksmanship) Musketoon +1
-					4219,	200,		-- (Ammunition) Stone Arrow Quiver
-					4227,	200,		-- (Ammunition) Bronze Bolt Quiver
-					5359,	200,		-- (Ammunition) Bronze Bullet Pouch
-					12744,	2000,		-- (Gloves) Cuffs +1
-					12897,  2000,       -- (Legs) Slops +1
-					12983,	2000,		-- (Feet) Ash Clogs +1
-					13060,	2000,		-- (Neck) Feather Collar +1
-					13117,	2000,		-- (Neck) Ranger's Necklace
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_RNG =
-				{
-					19106,	10000,      -- (Dagger) Thug's Jambiya +1
-					17180,	15000,		-- (Archery) Great Bow +1
-					17229,	15000,		-- (Marksmanship) Zamburak +1
-					17260,	15000,		-- (Marksmanship) Pirate's Gun +1
-					4222,	2000,		-- (Ammunition) Horn Arrow Quiver
-					4228,	2000,		-- (Ammunition) Mythril Bolt Quiver
-					5363,	2000,		-- (Ammunition) Bullet Pouch
-					15161,  10000,      -- (Head) Noct Beret
-					14422,  10000,      -- (Body) Noct Doublet
-					14854,  10000,      -- (Hands) Noct Gloves
-					14323,  10000,      -- (Legs) Noct Brais
-					15311,  10000,      -- (Feet) Noct Gaiters
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_RNG =
-				{
-					17603,  15000,      -- (Dagger) Cermet Kukri +1
-					17189,	25000,		-- (Archery) Rapid Bow +1
-					17227,	25000,		-- (Marksmanship) Heavy Crossbow +1
-					19227,	25000,		-- (Marksmanship) Blunderbuss +1
-					4224,	5000,		-- (Ammunition) Demon Arrow Quiver
-					4229,	5000,		-- (Ammunition) Darksteel Bolt Quiver
-					5353,	5000,		-- (Ammunition) Iron Bullet Pouch
-					15235,	50000,		-- (Head) Hunter's Beret +1
-					14483,	50000,		-- (Body) Hunter's Jerkin +1
-					14900,	50000,		-- (Hands) Hunter's Bracers +1
-					15571,	50000,		-- (Legs) Hunter's Braccae +1
-					15362,	50000,		-- (Feet) Hunter's Socks +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13369,	10000,		-- (Earring) Spike Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_RNG =
-				{
-					16481,  35000,      -- (Dagger) Yataghan +1
-					18701,	40000,		-- (Archery) Cerberus Bow +1
-					19266,	40000,		-- (Marksmanship) Darkwing +1
-					19268,	40000,		-- (Marksmanship) Ribauldequin +1
-					5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
-					5821,	7500,		-- (Ammunition) Fusion Bolt Quiver
-					5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
-					11074,	50000,		-- (Head) Sylvan Gapette +2
-					11094,	50000,		-- (Body) Sylvan Caban +2
-					11114,	50000,		-- (Hands) Sylvan Glovelettes +2
-					11134,	50000,		-- (Legs) Sylvan Bragues +2
-					11154,	50000,		-- (Feet) Sylvan Bottillons +2
-					11596,  50000,		-- (Neck) Sylvan Scarf
-					11713,  50000,		-- (Earring) Sylvan Earring
-					16205,  50000,		-- (Back) Sylvan Chlamys
-					10660,	50000,		-- (Head) Scout's Beret +2
-					10680,	50000,		-- (Body) Scout's Jerkin +2
-					10700,	50000,		-- (Hands) Scout's Bracers +2
-					10720,	50000,		-- (Legs) Scout's Braccae +2
-					10740,	50000,		-- (Feet) Scout's Socks +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11681,	30000,		-- (Earring) Breeze Earring
-					14636,	30000,		-- (Ring) Breeze Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_RNG =
-				{
-					20642,	65000,		-- (Dagger) Tzustes Knife +1
-					21244,  100000,     -- (Archery) Ahkormaar Bow +1
-					21259,  100000,     -- (Marksmanship) Malayo Crossbow +1
-					21293,  100000,     -- (Marksmanship) Bandeiras Gun +1
-					6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
-					6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
-					6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11074,	50000,		-- (Head) Sylvan Gapette +2
-					11094,	50000,		-- (Body) Sylvan Caban +2
-					11114,	50000,		-- (Hands) Sylvan Glovelettes +2
-					11134,	50000,		-- (Legs) Sylvan Bragues +2
-					11154,	50000,		-- (Feet) Sylvan Bottillons +2
-					11596,  50000,		-- (Neck) Sylvan Scarf
-					11713,  50000,		-- (Earring) Sylvan Earring
-					16205,  50000,		-- (Back) Sylvan Chlamys
-					10660,	50000,		-- (Head) Scout's Beret +2
-					10680,	50000,		-- (Body) Scout's Jerkin +2
-					10700,	50000,		-- (Hands) Scout's Bracers +2
-					10720,	50000,		-- (Legs) Scout's Braccae +2
-					10740,	50000,		-- (Feet) Scout's Socks +2
-					-- 25477,	50000,		-- (Neck) Scout's Gorget
-					11735,  50000,		-- (Waist) Impulse Belt
-					--26337,	50000,		-- (Waist) Kwahu Kachina Belt
-					11006,	50000,		-- (Back) Thall Mantle
-					11046,	50000,		-- (Earring) Ouesk Pearl
-					28513,	50000,		-- (Earring) Phawaylla Earring
-					11058,	50000,		-- (Ring) Hajduk Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_RNG)
-	elseif (job == xi.job.SAM) then
-		local stock_SAM = {}
-		player:PrintToPlayer(string.format("Andreine : Well met noble Samurai! There are demons which must taste the steel of your blade."),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_SAM =
-				{
-					17809,	5000,		-- (Great Katana) Mumeito
-					17177,	5000,		-- (Archery) Longbow +1
-					4219,	200,		-- (Ammunition) Stone Arrow Quiver
-					12774,	2000,		-- (Gloves) Tekko +1
-					12899,	2000,       -- (Legs) Sitabaki +1
-					13031,	2000,		-- (Feet) Kyahan +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_SAM =
-				{
-					16988,  15000,      -- (Great Katana) Kotetsu
-					17180,	15000,		-- (Archery) Great Bow +1
-					4222,	2000,		-- (Ammunition) Horn Arrow Quiver
-					12539,  10000,      -- (Head) Soil Hachimaki +1
-					12671,  10000,      -- (Body) Soil Gi +1
-					12781,  10000,      -- (Hands) Soil Tekko +1
-					12905,  10000,      -- (Legs) Soil Sitabaki +1
-					13035,  10000,      -- (Feet) Soil Kyahan +1
-					13070,	5000,		-- (Neck) Wolf Gorget +1
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13519,	5000,		-- (Ring) Mythril Ring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_SAM =
-				{
-					16990,  25000,      -- (Great Katana) Daihannya
-					17189,	25000,		-- (Archery) Rapid Bow +1
-					4224,	5000,		-- (Ammunition) Demon Arrow Quiver
-					15236,	50000,		-- (Head) Myochin Kabuto +1
-					14484,	50000,		-- (Body) Myochin Domaru +1
-					14901,	50000,		-- (Hands) Myochin Kote +1
-					15572,	50000,		-- (Legs) Myochin Haidate +1
-					15363,	50000,		-- (Feet) Myochin Sune-Ate +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13369,	10000,		-- (Earring) Spike Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_SAM =
-				{
-					16977,	40000,		-- (Great Katana) Yukitsugu +1
-					18701,	40000,		-- (Archery) Cerberus Bow +1
-					5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
-					11075,	50000,		-- (Head) Unkai Kabuto +2
-					11095,	50000,		-- (Body) Unkai Domaru +2
-					11115,	50000,		-- (Hands) Unkai Kote +2
-					11135,	50000,		-- (Legs) Unkai Haidate +2
-					11155,	50000,		-- (Feet) Unkai Sune-Ate +2
-					11597,  50000,		-- (Neck) Unkai Nodowa
-					11714,  50000,		-- (Earring) Unkai Mimikazari
-					16206,  50000,		-- (Back) Unkai Sugemino
-					10661,	50000,		-- (Head) Saotome Kabuto +2
-					10681,	50000,		-- (Body) Saotome Domaru +2
-					10701,	50000,		-- (Hands) Saotome Kote +2
-					10721,	50000,		-- (Legs) Saotome Haidate +2
-					10741,	50000,		-- (Feet) Saotome Sune-Ate +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11678,	30000,		-- (Earring) Flame Earring
-					14630,	30000,		-- (Ring) Flame Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_SAM =
-				{
-					21057,	100000,		-- (Great Katana) Tomonari +1
-					19787,  100000,     -- (Archery) Nurigomeyumi +1
-					6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11075,	50000,		-- (Head) Unkai Kabuto +2
-					11095,	50000,		-- (Body) Unkai Domaru +2
-					11115,	50000,		-- (Hands) Unkai Kote +2
-					11135,	50000,		-- (Legs) Unkai Haidate +2
-					11155,	50000,		-- (Feet) Unkai Sune-Ate +2
-					11597,  50000,		-- (Neck) Unkai Nodowa
-					11714,  50000,		-- (Earring) Unkai Mimikazari
-					16206,  50000,		-- (Back) Unkai Sugemino
-					10661,	50000,		-- (Head) Saotome Kabuto +2
-					10681,	50000,		-- (Body) Saotome Domaru +2
-					10701,	50000,		-- (Hands) Saotome Kote +2
-					10721,	50000,		-- (Legs) Saotome Haidate +2
-					10741,	50000,		-- (Feet) Saotome Sune-Ate +2
-					-- 25483,	50000,		-- (Neck) Samurai's Nodowa
-					10831,	50000,		-- (Waist) Paewr Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_SAM)
-	elseif (job == xi.job.NIN) then
-		local stock_NIN = {}
-		player:PrintToPlayer(string.format("Andreine : Oh! You Ninjas always startle me when you appear out of nowhere like that!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_NIN =
-				{
-					16914,	5000,		-- (Katana) Kunai +1
-					17307,	2,			-- (Throwing) Dart
-					6299,	500,		-- (Throwing) Shuriken Pouch
-					12774,	2000,		-- (Gloves) Tekko +1
-					12899,	2000,       -- (Legs) Sitabaki +1
-					13031,	2000,		-- (Feet) Kyahan +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_NIN =
-				{
-					16921,  10000,      -- (Katana) Kodachi +1
-					6297,	2000,		-- (Throwing) Juji Shuriken Pouch
-					12539,  10000,      -- (Head) Soil Hachimaki +1
-					12671,  10000,      -- (Body) Soil Gi +1
-					12781,  10000,      -- (Hands) Soil Tekko +1
-					12905,  10000,      -- (Legs) Soil Sitabaki +1
-					13035,  10000,      -- (Feet) Soil Kyahan +1
-					13070,	5000,		-- (Neck) Wolf Gorget +1
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13519,	5000,		-- (Ring) Mythril Ring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_NIN =
-				{
-					16923,  15000,      -- (Katana) Kabutowari +1
-					6302,	5000,		-- (Throwing) Fuma Shuriken Pouch
-					15237,	50000,		-- (Head) Ninja Hatsuburi +1
-					14485,	50000,		-- (Body) Ninja Chainmail +1
-					14902,	50000,		-- (Hands) Ninja Tekko +1
-					15573,	50000,		-- (Legs) Ninja Hakama +1
-					15364,	50000,		-- (Feet) Ninja Kyahan +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13369,	10000,		-- (Earring) Spike Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_NIN =
-				{
-					19286,	35000,		-- (Katana) Kakko +1
-					6300,	7500,		-- (Throwing) Koga Shuriken Pouch
-					11076,	50000,		-- (Head) Iga Zukin +2
-					11096,	50000,		-- (Body) Iga Ningi +2
-					11116,	50000,		-- (Hands) Iga Tekko +2
-					11136,	50000,		-- (Legs) Iga Hakama +2
-					11156,	50000,		-- (Feet) Iga Kyahan +2
-					11598,  50000,		-- (Neck) Iga Erimaki
-					11715,  50000,		-- (Earring) Iga Mimikazari
-					16207,  50000,		-- (Back) Iga Dochugappa
-					10662,	50000,		-- (Head) Koga Hatsuburi +2
-					10682,	50000,		-- (Body) Koga Chainmail +2
-					10702,	50000,		-- (Hands) Koga Tekko +2
-					10722,	50000,		-- (Legs) Koga Hakama +2
-					10742,	50000,		-- (Feet) Koga Kyahan +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11678,	30000,		-- (Earring) Flame Earring
-					14630,	30000,		-- (Ring) Flame Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_NIN =
-				{
-					21010,	65000,		-- (Katana) Nakajimarai +1
-					6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11076,	50000,		-- (Head) Iga Zukin +2
-					11096,	50000,		-- (Body) Iga Ningi +2
-					11116,	50000,		-- (Hands) Iga Tekko +2
-					11136,	50000,		-- (Legs) Iga Hakama +2
-					11156,	50000,		-- (Feet) Iga Kyahan +2
-					11598,  50000,		-- (Neck) Iga Erimaki
-					11715,  50000,		-- (Earring) Iga Mimikazari
-					16207,  50000,		-- (Back) Iga Dochugappa
-					10662,	50000,		-- (Head) Koga Hatsuburi +2
-					10682,	50000,		-- (Body) Koga Chainmail +2
-					10702,	50000,		-- (Hands) Koga Tekko +2
-					10722,	50000,		-- (Legs) Koga Hakama +2
-					10742,	50000,		-- (Feet) Koga Kyahan +2
-					-- 25489,	50000,		-- (Neck) Ninja Nodowa
-					10831,	50000,		-- (Waist) Paewr Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					28492,  50000,      -- (Earring) Hibernation Earring
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_NIN)
-	elseif (job == xi.job.DRG) then
-		local stock_DRG = {}
-		player:PrintToPlayer(string.format("Andreine : It's so good to see a Dragoon again! Give your wyvern a special treat from me!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_DRG =
-				{
-					16862,	5000,		-- (Polearm) Harpoon +1
-					12695,	2000,		-- (Gloves) Bronze Mittens +1
-					12823,  2000,       -- (Legs) Bronze Subligar +1
-					12951,	2000,		-- (Feet) Bronze Leggings +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_DRG =
-				{
-					16876,  15000,      -- (Polearm) Lance +1
-					13824,  10000,      -- (Head) Strong Bandana
-					13707,  10000,      -- (Body) Strong Vest
-					12786,  10000,      -- (Hands) Strong Gloves
-					12910,  10000,      -- (Legs) Strong Trousers
-					13039,  10000,      -- (Feet) Strong Boots
-					13070,	5000,		-- (Neck) Wolf Gorget +1
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13519,	5000,		-- (Ring) Mythril Ring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_DRG =
-				{
-					18119,  25000,      -- (Polearm) Dark Mezraq +1
-					18259,	200,		-- (Ammunition) Angon
-					15238,	50000,		-- (Head) Drachen Armet +1
-					14486,	50000,		-- (Body) Drachen Mail +1
-					14903,	50000,		-- (Hands) Drachen Finger Gauntlets +1
-					15574,	50000,		-- (Legs) Drachen Brais +1
-					15365,	50000,		-- (Feet) Drachen Greaves +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13403,	10000,		-- (Earring) Assault Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_DRG =
-				{
-					18111,	40000,		-- (Polearm) Mezraq +1
-					18259,	200,		-- (Ammunition) Angon
-					11077,	50000,		-- (Head) Lancer's Mezail +2
-					11097,	50000,		-- (Body) Lancer's Plackart +2
-					11117,	50000,		-- (Hands) Lancer's Vambraces +2
-					11137,	50000,		-- (Legs) Lancer's Cuissots +2
-					11157,	50000,		-- (Feet) Lancer's Schynbalds +2
-					11599,  50000,		-- (Neck) Lancer's Torque
-					11716,  50000,		-- (Earring) Lancer's Earring
-					16208,  50000,		-- (Back) Lancer's Pelerine
-					10663,	50000,		-- (Head) Wyrm Armet +2
-					10683,	50000,		-- (Body) Wyrm Mail +2
-					10703,	50000,		-- (Hands) Wyrm Finger Gauntlets +2
-					10723,	50000,		-- (Legs) Wyrm Brais +2
-					10743,	50000,		-- (Feet) Wyrm Greaves +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11678,	30000,		-- (Earring) Flame Earring
-					14630,	30000,		-- (Ring) Flame Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_DRG =
-				{
-					19799,  300000,		-- (Polearm) Herja's Fork
-					20968,	100000,		-- (Polearm) Chanar Xyston +1
-					18259,	200,		-- (Ammunition) Angon
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11077,	50000,		-- (Head) Lancer's Mezail +2
-					11097,	50000,		-- (Body) Lancer's Plackart +2
-					11117,	50000,		-- (Hands) Lancer's Vambraces +2
-					11137,	50000,		-- (Legs) Lancer's Cuissots +2
-					11157,	50000,		-- (Feet) Lancer's Schynbalds +2
-					11599,  50000,		-- (Neck) Lancer's Torque
-					11716,  50000,		-- (Earring) Lancer's Earring
-					16208,  50000,		-- (Back) Lancer's Pelerine
-					10663,	50000,		-- (Head) Wyrm Armet +2
-					10683,	50000,		-- (Body) Wyrm Mail +2
-					10703,	50000,		-- (Hands) Wyrm Finger Gauntlets +2
-					10723,	50000,		-- (Legs) Wyrm Brais +2
-					10743,	50000,		-- (Feet) Wyrm Greaves +2
-					-- 25495,	50000,		-- (Neck) Dragoon's Collar
-					10831,	50000,		-- (Waist) Paewr Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_DRG)
-	elseif (job == xi.job.SMN) then
-		local stock_SMN = {}
-		player:PrintToPlayer(string.format("Andreine : Greetings noble Summoner! Are all of the avatars getting along today?"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_SMN =
-				{
-					17123,	5000,		-- (Staff) Ash Staff +1
-					17122,	5000,		-- (Staff) Ash Pole +1
-					12744,	2000,		-- (Gloves) Cuffs +1
-					12897,  2000,       -- (Legs) Slops +1
-					12983,	2000,		-- (Feet) Ash Clogs +1
-					13093,	2000,		-- (Neck) Justice Badge
-					13190,	2000,		-- (Waist) Heko Obi +1
-					13605,	2000,		-- (Back) Cape +1
-					14694,	2000,		-- (Earring) Energy Earring +1
-					13440,	2000,		-- (Ring) Ascetic's Ring
-					13548,	50000,		-- (Ring) Astral Ring
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_SMN =
-				{
-					17534,	15000,		-- (Staff) Whale Staff +1
-					17119,	15000,		-- (Staff) Elm Pole +1
-					12538,  10000,      -- (Head) Red Cap +1
-					12625,  10000,      -- (Body) Gambison +1
-					12779,  10000,      -- (Hands) Bracers +1
-					12903,  10000,      -- (Legs) Hose +1
-					13034,  10000,      -- (Feet) Socks +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13233,	5000,		-- (Waist) Gold Obi +1
-					13618,	5000,		-- (Back) White Cape +1
-					14702,	5000,		-- (Earring) Aura Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_SMN =
-				{
-					17520,	25000,		-- (Staff) Heavy Staff +1
-					17521,	25000,		-- (Staff) Mahogany Pole +1
-					15239,	50000,		-- (Head) Evoker's Horn +1
-					14487,	50000,		-- (Body) Evoker's Doublet +1
-					14904,	50000,		-- (Hands) Evoker's Bracers +1
-					15575,	50000,		-- (Legs) Evoker's Spats +1
-					15366,	50000,		-- (Feet) Evoker's Pigaches +1
-					15887,	10000,		-- (Neck) Resolute Belt
-					15885,	10000,		-- (Neck) Spectral Belt
-					15490,	10000,		-- (Back) Miraculous Cape
-					15971,	10000,		-- (Earring) Antivenom Earring
-					15972,	10000,		-- (Earring) Insomnia Earring
-					15776,	10000,		-- (Ring) Ebullient Ring
-					15777,	10000,		-- (Ring) Hale Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_SMN =
-				{
-					17578,	40000,		-- (Staff) Zen Pole
-					17277,	20000,		-- (Ammunition) Hedgehog Bomb
-					11078,	50000,		-- (Head) Caller's Horn +2
-					11098,	50000,		-- (Body) Caller's Doublet +2
-					11118,	50000,		-- (Hands) Caller's Bracers +2
-					11138,	50000,		-- (Legs) Caller's Spats +2
-					11158,	50000,		-- (Feet) Caller's Pigaches +2
-					11619,  50000,		-- (Neck) Caller's Pendant
-					11717,  50000,		-- (Earring) Caller's Earring
-					11739,  50000,		-- (Back) Caller's Sash
-					10664,	50000,		-- (Head) Summoner's Horn +2
-					10684,	50000,		-- (Body) Summoner's Doublet +2
-					10704,	50000,		-- (Hands) Summoner's Bracers +2
-					10724,	50000,		-- (Legs) Summoner's Spats +2
-					10744,	50000,		-- (Feet) Summoner's Pigaches +2
-					11579,	30000,		-- (Neck) Fylgja Torque
-					15949,	30000,		-- (Waist) Pythia Sash +1
-					11564,	30000,		-- (Back) Tiresias' Cape
-					11685,	30000,		-- (Earring) Darkness Earring
-					14644,	30000,		-- (Ring) Dark Ring
-					14625,  100000,		-- (Ring) Evoker's Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_SMN =
-				{
-					21208,	100000,		-- (Staff) Lehbrailg
-					19780,	30000,		-- (Ammunition) Mana Ampulla
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11078,	50000,		-- (Head) Caller's Horn +2
-					11098,	50000,		-- (Body) Caller's Doublet +2
-					11118,	50000,		-- (Hands) Caller's Bracers +2
-					11138,	50000,		-- (Legs) Caller's Spats +2
-					11158,	50000,		-- (Feet) Caller's Pigaches +2
-					11619,  50000,		-- (Neck) Caller's Pendant
-					11717,  50000,		-- (Earring) Caller's Earring
-					11739,  50000,		-- (Back) Caller's Sash
-					10664,	50000,		-- (Head) Summoner's Horn +2
-					10684,	50000,		-- (Body) Summoner's Doublet +2
-					10704,	50000,		-- (Hands) Summoner's Bracers +2
-					10724,	50000,		-- (Legs) Summoner's Spats +2
-					10744,	50000,		-- (Feet) Summoner's Pigaches +2
-					-- 25501,	50000,		-- (Neck) Summoner's Collar
-					10842,	50000,		-- (Waist) Bougonia Rope
-					27607,	50000,		-- (Back) Thaumaturge's Cape
-					11021,	30000,		-- (Earring) Darkness Pearl
-					-- 27578,	30000,		-- (Ring) Fenrir Ring
-					14625,  100000,		-- (Ring) Evoker's Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_SMN)
-	elseif (job == xi.job.BLU) then
-		local stock_BLU = {}
-		player:PrintToPlayer(string.format("Andreine : You may know the secrets of monster techniques Blue Mage but I have the gear you'll need!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_BLU =
-				{
-					16610,	5000,		-- (Sword) Wax Sword +1
-					12695,	2000,		-- (Gloves) Bronze Mittens +1
-					12823,  2000,       -- (Legs) Bronze Subligar +1
-					12951,	2000,		-- (Feet) Bronze Leggings +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13190,	2000,		-- (Waist) Heko Obi +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					14694,	2000,		-- (Earring) Energy Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_BLU =
-				{
-					17740,  15000,      -- (Sword) Steel Kilij +1
-					15173,  10000,      -- (Head) Kosshin
-					13730,  10000,      -- (Body) Frost Robe
-					12750,  10000,      -- (Hands) New Moon Armlets
-					12904,  10000,      -- (Legs) Linen Slacks +1
-					13040,  10000,      -- (Feet) Shoes +1
-					13070,	5000,		-- (Neck) Wolf Gorget +1
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13506,	5000,		-- (Ring) Bomb Ring
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_BLU =
-				{
-					17639,  25000,      -- (Sword) Cutlass +1
-					11464,	50000,		-- (Head) Magus Keffiyeh +1
-					11291,	50000,		-- (Body) Magus Jubbah +1
-					15024,	50000,		-- (Hands) Magus Bazubands +1
-					16345,	50000,		-- (Legs) Magus Shalwar +1
-					11381,	50000,		-- (Feet) Magus Charuqs +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15887,	10000,		-- (Waist) Resolute Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13369,	10000,		-- (Earring) Spike Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_BLU =
-				{
-					17664,  40000,      -- (Sword) Firmament +1
-					11079,	50000,		-- (Head) Mavi Kavuk +2
-					11099,	50000,		-- (Body) Mavi Mintan +2
-					11119,	50000,		-- (Hands) Mavi Bazubands +2
-					11139,	50000,		-- (Legs) Mavi Tayt +2
-					11159,	50000,		-- (Feet) Mavi Basmak +2
-					19255,  50000,		-- (Ammunition) Mavi Tathlum
-					11600,  50000,		-- (Neck) Mavi Scarf
-					11718,  50000,		-- (Earring) Mavi Earring
-					10665,	50000,		-- (Head) Mirage Keffiyeh +2
-					10685,	50000,		-- (Body) Mirage Jubbah +2
-					10705,	50000,		-- (Hands) Mirage Bazubands +2
-					10725,	50000,		-- (Legs) Mirage Shalwar +2
-					10745,	50000,		-- (Feet) Mirage Charuqs +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11678,	30000,		-- (Earring) Flame Earring
-					14630,	30000,		-- (Ring) Flame Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_BLU =
-				{
-					18916,  300000,		-- (Sword) Heimdall's Doom
-					20743,	100000,		-- (Sword) Bihkah Sword +1
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11079,	50000,		-- (Head) Mavi Kavuk +2
-					11099,	50000,		-- (Body) Mavi Mintan +2
-					11119,	50000,		-- (Hands) Mavi Bazubands +2
-					11139,	50000,		-- (Legs) Mavi Tayt +2
-					11159,	50000,		-- (Feet) Mavi Basmak +2
-					19255,  50000,		-- (Ammunition) Mavi Tathlum
-					11600,  50000,		-- (Neck) Mavi Scarf
-					11718,  50000,		-- (Earring) Mavi Earring
-					10665,	50000,		-- (Head) Mirage Keffiyeh +2
-					10685,	50000,		-- (Body) Mirage Jubbah +2
-					10705,	50000,		-- (Hands) Mirage Bazubands +2
-					10725,	50000,		-- (Legs) Mirage Shalwar +2
-					10745,	50000,		-- (Feet) Mirage Charuqs +2
-					-- 25507,	50000,		-- (Neck) Mirage Stole
-					10831,	50000,		-- (Waist) Paewr Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_BLU)
-	elseif (job == xi.job.COR) then
-		local stock_COR = {}
-		player:PrintToPlayer(string.format("Andreine : Ready to roll the dice Corsair? I wish you the best of luck out there!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_COR =
-				{
-					16624,	5000,		-- (Sword) Xiphos +1
-					16491,	5000,		-- (Dagger) Bronze Knife +1
-					19225,	5000,		-- (Marksmanship) Musketoon +1
-					5359,	200,		-- (Ammunition) Bronze Bullet Pouch
-					12695,	2000,		-- (Gloves) Bronze Mittens +1
-					12823,  2000,       -- (Legs) Bronze Subligar +1
-					12951,	2000,		-- (Feet) Bronze Leggings +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_COR =
-				{
-					19106,	10000,      -- (Dagger) Thug's Jambiya +1
-					17260,	15000,		-- (Marksmanship) Pirate's Gun +1
-					5363,	2000,		-- (Ammunition) Bullet Pouch
-					15161,  10000,      -- (Head) Noct Beret
-					14422,  10000,      -- (Body) Noct Doublet
-					14854,  10000,      -- (Hands) Noct Gloves
-					14323,  10000,      -- (Legs) Noct Brais
-					15311,  10000,      -- (Feet) Noct Gaiters
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_COR =
-				{
-					17603,  15000,      -- (Dagger) Cermet Kukri +1
-					19227,	25000,		-- (Marksmanship) Blunderbuss +1
-					5353,	5000,		-- (Ammunition) Iron Bullet Pouch
-					11467,	50000,		-- (Head) Corsair's Tricorne +1
-					11294,	50000,		-- (Body) Corsair's Frac +1
-					15027,	50000,		-- (Hands) Corsair's Gants +1
-					16348,	50000,		-- (Legs) Corsair's Culottes +1
-					11384,	50000,		-- (Feet) Corsair's Bottes +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13369,	10000,		-- (Earring) Spike Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_COR =
-				{
-					16481,  35000,      -- (Dagger) Yataghan +1
-					19268,	40000,		-- (Marksmanship) Ribauldequin +1
-					5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
-					11080,	50000,		-- (Head) Navarch's Tricorne +2
-					11100,	50000,		-- (Body) Navarch's Frac +2
-					11120,	50000,		-- (Hands) Navarch's Gants +2
-					11140,	50000,		-- (Legs) Navarch's Culottes +2
-					11160,	50000,		-- (Feet) Navarch's Bottes +2
-					11601,  50000,		-- (Neck) Navarch's Choker
-					11719,  50000,		-- (Earring) Navarch's Earring
-					16209,  50000,		-- (Back) Navarch's Mantle
-					10666,	50000,		-- (Head) Commodore Tricorne +2
-					10686,	50000,		-- (Body) Commodore Frac +2
-					10706,	50000,		-- (Hands) Commodore Gants +2
-					10726,	50000,		-- (Legs) Commodore Trews +2
-					10746,	50000,		-- (Feet) Commodore Bottes +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11681,	30000,		-- (Earring) Breeze Earring
-					14636,	30000,		-- (Ring) Breeze Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_COR =
-				{
-					20642,	65000,		-- (Dagger) Tzustes Knife +1
-					21293,  100000,     -- (Marksmanship) Bandeiras Gun +1
-					6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11080,	50000,		-- (Head) Navarch's Tricorne +2
-					11100,	50000,		-- (Body) Navarch's Frac +2
-					11120,	50000,		-- (Hands) Navarch's Gants +2
-					11140,	50000,		-- (Legs) Navarch's Culottes +2
-					11160,	50000,		-- (Feet) Navarch's Bottes +2
-					11601,  50000,		-- (Neck) Navarch's Choker
-					11719,  50000,		-- (Earring) Navarch's Earring
-					16209,  50000,		-- (Back) Navarch's Mantle
-					10666,	50000,		-- (Head) Commodore Tricorne +2
-					10686,	50000,		-- (Body) Commodore Frac +2
-					10706,	50000,		-- (Hands) Commodore Gants +2
-					10726,	50000,		-- (Legs) Commodore Trews +2
-					10746,	50000,		-- (Feet) Commodore Bottes +2
-					-- 25513,	50000,		-- (Neck) Commodore Charm
-					26337,	50000,		-- (Waist) Kwahu Kachina Belt
-					11006,	50000,		-- (Back) Thall Mantle
-					11046,	50000,		-- (Earring) Ouesk Pearl
-					28513,	50000,		-- (Earring) Phawaylla Earring
-					-- 27572,	50000,		-- (Ring) Garuda Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_COR)
-	elseif (job == xi.job.PUP) then
-		local stock_PUP = {}
-		player:PrintToPlayer(string.format("Andreine : Oh, how wonderful to see a Puppetmaster! Such finesse in controlling your puppet!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_PUP =
-				{
-					17476,	5000,		-- (Hand-to-Hand) Cat Baghnakhs +1
-					17859,	1000,		-- (Ranged) Animator
-					12744,	2000,		-- (Gloves) Cuffs +1
-					12897,  2000,       -- (Legs) Slops +1
-					12983,	2000,		-- (Feet) Ash Clogs +1
-					16282,	2000,		-- (Neck) Buffoon's Collar +1
-					13226,	2000,		-- (Waist) Blood Stone +1
-					13605,	2000,		-- (Back) Cape +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_PUP =
-				{
-					16445,	15000,		-- (Hand-to-Hand) Claws +1
-					17858,	5000,		-- (Ranged) Turbo Animator
-					12538,  10000,      -- (Head) Red Cap +1
-					12625,  10000,      -- (Body) Gambison +1
-					12779,  10000,      -- (Hands) Bracers +1
-					12903,  10000,      -- (Legs) Hose +1
-					13034,  10000,      -- (Feet) Socks +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13233,	5000,		-- (Waist) Gold Obi +1
-					13643,	5000,		-- (Back) Sarcenet Cape +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13519,	5000,		-- (Ring) Mythril Ring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_PUP =
-				{
-					18751,  25000,      -- (Hand-to-Hand) Black Adargas +1
-					17857,	15000,		-- (Ranged) Animator +1
-					11470,	50000,		-- (Head) Puppetry Taj +1
-					11297,	50000,		-- (Body) Puppetry Tobe +1
-					15030,	50000,		-- (Hands) Puppetry Dastanas +1
-					16351,	50000,		-- (Legs) Puppetry Churidars +1
-					11387,	50000,		-- (Feet) Puppetry Babouches +1
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15492,	10000,		-- (Back) Intensifying Cape
-					13369,	10000,		-- (Earring) Spike Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_PUP =
-				{
-					18775,	40000,		-- (Hand-to-Hand) Savate Fists +1
-					17923,	25000,		-- (Ranged) Deluxe Animator
-					19249,	20000,		-- (Ammunition) Thew Bomblet
-					11081,	50000,		-- (Head) Cirque Capello +2
-					11101,	50000,		-- (Body) Cirque Farsetto +2
-					11121,	50000,		-- (Hands) Cirque Guanti +2
-					11141,	50000,		-- (Legs) Cirque Pantaloni +2
-					11161,	50000,		-- (Feet) Cirque Scarpe +2
-					11602,  50000,		-- (Neck) Cirque Necklace
-					11720,  50000,		-- (Earring) Cirque Earring
-					11751,  50000,		-- (Waist) Cirque Sash
-					10667,	50000,		-- (Head) Pantin Taj +2
-					10687,	50000,		-- (Body) Pantin Tobe +2
-					10707,	50000,		-- (Hands) Pantin Dastanas +2
-					10727,	50000,		-- (Legs) Pantin Churidars +2
-					10747,	50000,		-- (Feet) Pantin Babouches +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11678,	30000,		-- (Earring) Flame Earring
-					14630,	30000,		-- (Ring) Flame Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_PUP =
-				{
-					20552,	100000,		-- (Hand-to-Hand) Akua Sainti +1
-					17923,	25000,		-- (Ranged) Deluxe Animator
-					19249,	20000,		-- (Ammunition) Thew Bomblet
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11081,	50000,		-- (Head) Cirque Capello +2
-					11101,	50000,		-- (Body) Cirque Farsetto +2
-					11121,	50000,		-- (Hands) Cirque Guanti +2
-					11141,	50000,		-- (Legs) Cirque Pantaloni +2
-					11161,	50000,		-- (Feet) Cirque Scarpe +2
-					11602,  50000,		-- (Neck) Cirque Necklace
-					11720,  50000,		-- (Earring) Cirque Earring
-					11751,  50000,		-- (Waist) Cirque Sash
-					10667,	50000,		-- (Head) Pantin Taj +2
-					10687,	50000,		-- (Body) Pantin Tobe +2
-					10707,	50000,		-- (Hands) Pantin Dastanas +2
-					10727,	50000,		-- (Legs) Pantin Churidars +2
-					10747,	50000,		-- (Feet) Pantin Babouches +2
-					-- 25519,	50000,		-- (Neck) Puppetmaster's Collar
-					10831,	50000,		-- (Waist) Paewr Belt
-					10987,	50000,		-- (Back) Meanagh Cape
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_PUP)
-	elseif (job == xi.job.DNC) then
-		local stock_DNC = {}
-		player:PrintToPlayer(string.format("Andreine : The graceful movements of you Dancers are always so hypnotizing!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_DNC =
-				{
-					16690,	5000,		-- (Hand-to-Hand) Cesti +1
-					16491,	5000,		-- (Dagger) Bronze Knife +1
-					12695,	2000,		-- (Gloves) Bronze Mittens +1
-					12823,  2000,       -- (Legs) Bronze Subligar +1
-					12951,	2000,		-- (Feet) Bronze Leggings +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-			xi.shop.general(player, stock_DNC)
-		elseif (level <= 60) then
-			stock_DNC =
-				{
-					19106,	10000,      -- (Dagger) Thug's Jambiya +1
-					12538,  10000,      -- (Head) Red Cap +1
-					12625,  10000,      -- (Body) Gambison +1
-					12779,  10000,      -- (Hands) Bracers +1
-					12903,  10000,      -- (Legs) Hose +1
-					13034,  10000,      -- (Feet) Socks +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_DNC =
-				{
-					17603,  15000,      -- (Dagger) Cermet Kukri +1
-					11476,	50000,		-- (Head) Dancer's Tiara +1 (Female)
-					11303,	50000,		-- (Body) Dancer's Casaque +1 (Female)
-					15036,	50000,		-- (Hands) Dancer's Bangles +1 (Female)
-					16358,	50000,		-- (Legs) Dancer's Tights +1 (Female)
-					11394,	50000,		-- (Feet) Dancer's Toe Shoes +1 (Female)
-					11475,	50000,		-- (Head) Dancer's Tiara +1 (Male)
-					11302,	50000,		-- (Body) Dancer's Casaque +1 (Male)
-					15035,	50000,		-- (Hands) Dancer's Bangles +1 (Male)
-					16357,	50000,		-- (Legs) Dancer's Tights +1 (Male)
-					11393,	50000,		-- (Feet) Dancer's Toe Shoes +1 (Male)
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13369,	10000,		-- (Earring) Spike Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_DNC =
-				{
-					16481,  35000,      -- (Dagger) Yataghan +1
-					11082,	50000,		-- (Head) Charis Tiara +2
-					11102,	50000,		-- (Body) Charis Casaque +2
-					11122,	50000,		-- (Hands) Charis Bangles +2
-					11142,	50000,		-- (Legs) Charis Tights +2
-					11162,	50000,		-- (Feet) Charis Toe Shoes +2
-					19256,  50000,		-- (Ammunition) Charis Feather
-					11603,  50000,		-- (Neck) Charis Necklace
-					11721,  50000,		-- (Earring) Charis Earring
-					10668,	50000,		-- (Head) Etoile Tiara +2
-					10688,	50000,		-- (Body) Etoile Casaque +2
-					10708,	50000,		-- (Hands) Etoile Bangles +2
-					10728,	50000,		-- (Legs) Etoile Tights +2
-					10748,	50000,		-- (Feet) Etoile Toe Shoes +2
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11679,	30000,		-- (Earring) Thunder Earring
-					14638,	30000,		-- (Ring) Thunder Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_DNC =
-				{
-					20642,	65000,		-- (Dagger) Tzustes Knife +1
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11082,	50000,		-- (Head) Charis Tiara +2
-					11102,	50000,		-- (Body) Charis Casaque +2
-					11122,	50000,		-- (Hands) Charis Bangles +2
-					11142,	50000,		-- (Legs) Charis Tights +2
-					11162,	50000,		-- (Feet) Charis Toe Shoes +2
-					19256,  50000,		-- (Ammunition) Charis Feather
-					11603,  50000,		-- (Neck) Charis Necklace
-					11721,  50000,		-- (Earring) Charis Earring
-					10668,	50000,		-- (Head) Etoile Tiara +2
-					10688,	50000,		-- (Body) Etoile Casaque +2
-					10708,	50000,		-- (Hands) Etoile Bangles +2
-					10728,	50000,		-- (Legs) Etoile Tights +2
-					10748,	50000,		-- (Feet) Etoile Toe Shoes +2
-					-- 25525,	50000,		-- (Neck) Etoile Gorget
-					10831,	50000,		-- (Waist) Paewr Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_DNC)
-	elseif (job == xi.job.SCH) then
-		local stock_SCH = {}
-		player:PrintToPlayer(string.format("Andreine : You've got the book knowledge Scholar, now you just need the gear!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_SCH =
-				{
-					17087,	5000,		-- (Club) Maple Wand +1
-					17137,	5000,		-- (Club) Ash Club +1
-					17123,	5000,		-- (Staff) Ash Staff +1
-					17122,	5000,		-- (Staff) Ash Pole +1
-					12744,	2000,		-- (Gloves) Cuffs +1
-					12897,  2000,       -- (Legs) Slops +1
-					12983,	2000,		-- (Feet) Ash Clogs +1
-					13093,	2000,		-- (Neck) Justice Badge
-					13190,	2000,		-- (Waist) Heko Obi +1
-					13605,	2000,		-- (Back) Cape +1
-					14694,	2000,		-- (Earring) Energy Earring +1
-					13440,	2000,		-- (Ring) Ascetic's Ring
-					13475,	2000,		-- (Ring) Hermit's Ring
-					13548,	50000,		-- (Ring) Astral Ring
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-			xi.shop.general(player, stock_SCH)
-		elseif (level <= 60) then
-			stock_SCH =
-				{
-					17141,	15000,		-- (Club) Solid Wand
-					17409,	15000,		-- (Club) Mythril Rod +1
-					17534,	15000,		-- (Staff) Whale Staff +1
-					17119,	15000,		-- (Staff) Elm Pole +1
-					15173,  10000,      -- (Head) Kosshin
-					13730,  10000,      -- (Body) Frost Robe
-					12750,  10000,      -- (Hands) New Moon Armlets
-					12904,  10000,      -- (Legs) Linen Slacks +1
-					13040,  10000,      -- (Feet) Shoes +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13233,	5000,		-- (Waist) Gold Obi +1
-					13610,	5000,		-- (Back) Black Cape +1
-					14702,	5000,		-- (Earring) Aura Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_SCH =
-				{
-					17427,	25000,		-- (Club) Ebony Wand +1
-					17435,	25000,		-- (Club) Darksteel Rod +1
-					17520,	25000,		-- (Staff) Heavy Staff +1
-					17521,	25000,		-- (Staff) Mahogany Pole +1
-					11477,	50000,		-- (Head) Scholar's Mortarboard +1
-					11304,	50000,		-- (Body) Scholar's Gown +1
-					15037,	50000,		-- (Hands) Scholar's Bracers +1
-					16359,	50000,		-- (Legs) Scholar's Pants +1
-					11395,	50000,		-- (Feet) Scholar's Loafers +1
-					15887,	10000,		-- (Neck) Resolute Belt
-					15885,	10000,		-- (Neck) Spectral Belt
-					15490,	10000,		-- (Back) Miraculous Cape
-					15971,	10000,		-- (Earring) Antivenom Earring
-					15972,	10000,		-- (Earring) Insomnia Earring
-					15776,	10000,		-- (Ring) Ebullient Ring
-					15777,	10000,		-- (Ring) Hale Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_SCH =
-				{
-					17118,	40000,		-- (Staff) Lituus +1
-					17277,	20000,		-- (Ammunition) Hedgehog Bomb
-					11083,	50000,		-- (Head) Savant's Bonnet +2
-					11103,	50000,		-- (Body) Savant's Gown +2
-					11123,	50000,		-- (Hands) Savant's Bracers +2
-					11143,	50000,		-- (Legs) Savant's Pants +2
-					11163,	50000,		-- (Feet) Savant's Loafers +2
-					19247,  50000,		-- (Ammunition) Savant's Treatise
-					11620,  50000,		-- (Neck) Savant's Chain
-					11722,  50000,		-- (Earring) Savant's Earring
-					10669,	50000,		-- (Head) Argute Mortarboard +2
-					10689,	50000,		-- (Body) Argute Gown +2
-					10709,	50000,		-- (Hands) Argute Bracers +2
-					10729,	50000,		-- (Legs) Argute Pants +2
-					10749,	50000,		-- (Feet) Argute Loafers +2
-					11579,	30000,		-- (Neck) Fylgja Torque
-					11584,	30000,		-- (Neck) Lemegeton Medallion +1
-					15949,	30000,		-- (Waist) Pythia Sash +1
-					11743,	30000,		-- (Waist) Searing Sash
-					27598,	30000,		-- (Back) Dew Silk Cape +1
-					11560,	30000,		-- (Back) Pedant Cape
-					11683,	30000,		-- (Earring) Aqua Earring
-					11682,	30000,		-- (Earring) Snow Earring
-					13308,	30000,		-- (Ring) Communion Ring
-					13306,	30000,		-- (Ring) Omniscient Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_SCH =
-				{
-					21133,	100000,		-- (Club) Sasah Wand +1
-					21208,	100000,		-- (Staff) Lehbrailg
-					-- 21362,	30000,		-- (Ammunition) Ombre Tathlum +1
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					11083,	50000,		-- (Head) Savant's Bonnet +2
-					11103,	50000,		-- (Body) Savant's Gown +2
-					11123,	50000,		-- (Hands) Savant's Bracers +2
-					11143,	50000,		-- (Legs) Savant's Pants +2
-					11163,	50000,		-- (Feet) Savant's Loafers +2
-					19247,  50000,		-- (Ammunition) Savant's Treatise
-					11620,  50000,		-- (Neck) Savant's Chain
-					11722,  50000,		-- (Earring) Savant's Earring
-					10669,	50000,		-- (Head) Argute Mortarboard +2
-					10689,	50000,		-- (Body) Argute Gown +2
-					10709,	50000,		-- (Hands) Argute Bracers +2
-					10729,	50000,		-- (Legs) Argute Pants +2
-					10749,	50000,		-- (Feet) Argute Loafers +2
-					-- 25531,	50000,		-- (Neck) Argute Stole
-					28455,	50000,		-- (Waist) Ovate Rope
-					10839,	50000,		-- (Waist) Othila Sash
-					28596,	50000,		-- (Back) Oretania's Cape +1
-					28601,	50000,		-- (Back) Seshaw Cape
-					11683,	30000,		-- (Earring) Aqua Earring
-					11682,	30000,		-- (Earring) Snow Earring
-					13308,	30000,		-- (Ring) Communion Ring
-					13306,	30000,		-- (Ring) Omniscient Ring
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_SCH)
-	elseif (job == xi.job.GEO) then
-		local stock_GEO = {}
-		player:PrintToPlayer(string.format("Andreine : Geomancers are always so spaced out when they come in here!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_GEO =
-				{
-					17087,	5000,		-- (Club) Maple Wand +1
-					17137,	5000,		-- (Club) Ash Club +1
-					17144,	5000,		-- (Club) Bronze Hammer +1
-					21460,	1000,		-- (Handbell) Matre Bell
-					12744,	2000,		-- (Gloves) Cuffs +1
-					12897,  2000,       -- (Legs) Slops +1
-					12983,	2000,		-- (Feet) Ash Clogs +1
-					13093,	2000,		-- (Neck) Justice Badge
-					13190,	2000,		-- (Waist) Heko Obi +1
-					13605,	2000,		-- (Back) Cape +1
-					14694,	2000,		-- (Earring) Energy Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					13548,	50000,		-- (Ring) Astral Ring
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_GEO =
-				{
-					17141,	15000,		-- (Club) Solid Wand
-					17409,	15000,		-- (Club) Mythril Rod +1
-					15173,  10000,      -- (Head) Kosshin
-					13730,  10000,      -- (Body) Frost Robe
-					12750,  10000,      -- (Hands) New Moon Armlets
-					12904,  10000,      -- (Legs) Linen Slacks +1
-					13040,  10000,      -- (Feet) Shoes +1
-					13102,	5000,		-- (Neck) Paisley Scarf
-					13233,	5000,		-- (Waist) Gold Obi +1
-					13610,	5000,		-- (Back) Black Cape +1
-					14702,	5000,		-- (Earring) Aura Earring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_GEO =
-				{
-					17427,	25000,		-- (Club) Ebony Wand +1
-					17435,	25000,		-- (Club) Darksteel Rod +1
-					12141,	50000,		-- (Head) Ebon Beret
-					12177,	50000,		-- (Body)  Ebon Frock
-					12213,	50000,		-- (Hands) Ebon Mitts
-					12249,	50000,		-- (Legs) Ebon Slops
-					12285,	50000,		-- (Feet) Ebon Clogs
-					15887,	10000,		-- (Neck) Resolute Belt
-					15885,	10000,		-- (Neck) Spectral Belt
-					15490,	10000,		-- (Back) Miraculous Cape
-					15971,	10000,		-- (Earring) Antivenom Earring
-					15972,	10000,		-- (Earring) Insomnia Earring
-					15776,	10000,		-- (Ring) Ebullient Ring
-					15777,	10000,		-- (Ring) Hale Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_GEO =
-				{
-					18875,	40000,		-- (Club) Vodun Mace
-					17277,	20000,		-- (Ammunition) Hedgehog Bomb
-					11505,	50000,		-- (Head) Teal Chapeau
-					13778,	50000,		-- (Body) Teal Saio
-					12747,	50000,		-- (Hands) Teal Cuffs
-					14258,	50000,		-- (Legs) Teal Slops
-					11415,	50000,		-- (Feet) Teal Pigaches
-					11807,	50000,		-- (Head) Nebula Hat +1
-					11849,	50000,		-- (Body) Nebula Houppelande +1
-					11916,	50000,		-- (Hands) Nebula Cuffs +1
-					11955,	50000,		-- (Legs) Nebula Slops +1
-					11452,	50000,		-- (Feet) Nebula Pigaches +1
-					11584,	30000,		-- (Neck) Lemegeton Medallion +1
-					11743,	30000,		-- (Waist) Searing Sash
-					11560,	30000,		-- (Back) Pedant Cape
-					11682,	30000,		-- (Earring) Snow Earring
-					13306,	30000,		-- (Ring) Omniscient Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_GEO =
-				{
-					21133,	100000,		-- (Club) Sasah Wand +1
-					21461,	50000,		-- (Handbell) Filiae Bell
-					-- 21362,	30000,		-- (Ammunition) Ombre Tathlum +1
-					27743,	100000,		-- (Head) Temachtiani Headband
-					27884,	100000,		-- (Body) Temachtiani Shirt
-					28032,	100000,		-- (Hands) Temachtiani Gloves
-					28171,	100000,		-- (Legs) Temachtiani Pants
-					28309,	100000,		-- (Feet) Temachtiani Boots
-					-- 25537,	50000,		-- (Neck) Bagua Charm
-					10839,	50000,		-- (Waist) Othila Sash
-					28601,	50000,		-- (Back) Seshaw Cape
-					11682,	30000,		-- (Earring) Snow Earring
-					-- 27574,	50000,		-- (Ring) Shiva Ring
-					4044,   16667,		-- Atramenterrane (Reforged Artifact Material)
-					4043,   16667,		-- Lavarion (Reforged Artifact Material)
-					4042,   16667,		-- Acuex Ore (Reforged Artifact Material)
-					4030,   16667,		-- Sekishitsu (Reforged Artifact Material)
-					4045,   16667,		-- Cyclone Cotton (Reforged Artifact Material)
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_GEO)
-	elseif (job == xi.job.RUN) then
-		local stock_RUN = {}
-		player:PrintToPlayer(string.format("Andreine : Mysterious runes? High magical defenses? 100%% Rune Fencer!"),xi.msg.channel.NS_SAY)
-		
-		if (level <= 30) then
-			stock_RUN =
-				{
-					20781,	5000,		-- (Great Sword) Sowilo Claymore
-					17307,	2,			-- (Ammunition) Dart
-					12695,	2000,		-- (Gloves) Bronze Mittens +1
-					12823,  2000,       -- (Legs) Bronze Subligar +1
-					12951,	2000,		-- (Feet) Bronze Leggings +1
-					13069,	2000,		-- (Neck) Leather Gorget +1
-					13210,	2000,		-- (Waist) Leather Belt +1
-					13599,	2000,		-- (Back) Rabbit Mantle +1
-					14695,	2000,		-- (Earring) Hope Earring +1
-					14694,	2000,		-- (Earring) Energy Earring +1
-					13492,	2000,		-- (Ring) Copper Ring +1
-					-- 317,	100000,		-- (Item) Bronze Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 60) then
-			stock_RUN =
-				{
-					16936,	15000,		-- (Great Sword) Demonic Sword
-					12538,  10000,      -- (Head) Red Cap +1
-					12625,  10000,      -- (Body) Gambison +1
-					12779,  10000,      -- (Hands) Bracers +1
-					12903,  10000,      -- (Legs) Hose +1
-					13034,  10000,      -- (Feet) Socks +1
-					13070,	5000,		-- (Neck) Wolf Gorget +1
-					13223,	5000,		-- (Waist) Silver Belt +1
-					13609,	5000,		-- (Back) Wolf Mantle +1
-					14703,	5000,		-- (Earring) Loyalty Earring +1
-					13519,	5000,		-- (Ring) Mythril Ring +1
-					-- 318,	150000,		-- (Item) Crystal Rose (Used to trigger augment application trades)
-				}
-		elseif (level <= 75) then
-			stock_RUN =
-				{
-					16616,	25000,		-- (Great Sword) Zweihander +1
-					12120,	50000,		-- (Head) Ebon Mask
-					12156,	50000,		-- (Body) Ebon Harness
-					12192,	50000,		-- (Hands) Ebon Gloves
-					12228,	50000,		-- (Legs) Ebon Brais
-					12264,	50000,		-- (Feet) Ebon Boots
-					15523,	10000,		-- (Neck) Chivalrous Chain
-					15524,	10000,		-- (Neck) Fortified Chain
-					15521,	10000,		-- (Neck) Tempered Chain
-					15884,	10000,		-- (Waist) Potent Belt
-					15493,	10000,		-- (Back) Bushido Cape
-					13369,	10000,		-- (Earring) Spike Earring
-					14764,	10000,		-- (Earring) Minuet Earring
-					13545,	10000,		-- (Ring) Demon's Ring +1
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level < 99) then
-			stock_RUN =
-				{
-					19166,	40000,		-- (Great Sword) Cratus Sword +1
-					16074,	50000,		-- (Head) Hydra Mask +1
-					14538,	50000,		-- (Body) Hydra Mail +1
-					14950,	50000,		-- (Hands) Hydra Finger Gauntlets +1
-					15616,	50000,		-- (Legs) Hydra Cuisses +1
-					15704,	50000,		-- (Feet) Hydra Greaves +1
-					11803,	50000,		-- (Head) Alcide's Cap +1
-					11845,	50000,		-- (Body) Alcide's Harness +1
-					11912,	50000,		-- (Hands) Alcide's Mitts +1
-					11951,	50000,		-- (Legs) Alcide's Subligar +1
-					11448,	50000,		-- (Feet) Alcide's Leggings +1
-					13146,	30000,		-- (Neck) Tern Necklace
-					15922,	30000,		-- (Waist) Tern Stone
-					13619,	30000,		-- (Back) Tern Cape
-					11678,	30000,		-- (Earring) Flame Earring
-					14630,	30000,		-- (Ring) Flame Ring
-					-- 139,	250000,		-- (Item) Star Globe (Used to trigger augment application trades)
-				}
-		elseif (level == 99) then
-			stock_RUN =
-				{
-					20788,	100000,		-- (Great Sword) Hatzoaar Sword +1
-					20786,	100000,		-- (Great Sword) Thurisaz Blade +1
-					10435,	100000,		-- (Head) Dux Visor +1
-					10273,	100000,		-- (Body) Dux Scale Mail +1
-					10317,	100000,		-- (Hands) Dux Finger Gauntlets +1
-					10347,	100000,		-- (Legs) Dux Cuisses +1
-					10364,	100000,		-- (Feet) Dux Greaves +1
-					-- 25543,	50000,		-- (Neck) Futhark Torque
-					10831,	50000,		-- (Waist) Paewr Belt
-					10992,	50000,		-- (Back) Vassal's Mantle
-					11057,	50000,		-- (Earring) Ghillie Earring +1
-					10797,	50000,		-- (Ring) Dagaz Ring
-					10798,	50000,		-- (Ring) Eihwaz Ring
-					4046,   16667,		-- Corroded Ore (Reforged Artifact Material)
-					4025,   16667,		-- Snowsteel Sheet (Reforged Artifact Material)
-					4047,   16667,		-- Redoubtable Silk Thread (Reforged Artifact Material)
-					3923,   16667,		-- Rhodium Ingot (Reforged Artifact Material)
-					4029,   16667,		-- Runeweave (Reforged Artifact Material)
-					-- 321,	350000,		-- (Item) Mythril Bell (Used to trigger augment application trades)
-				}
-		end
-		
-		xi.shop.general(player, stock_RUN)
-	end
-	player:PrintToPlayer(string.format("Andreine's stock changes when you reach levels 31, 61, 76, and 99."),xi.msg.channel.SYSTEM_3)
+    local job = player:getMainJob()
+    local level = player:getMainLvl()
+    
+    if (job == xi.job.WAR) then
+        local stock_WAR = {}
+        player:PrintToPlayer(string.format("Andreine : I've got gear to get your Warrior's arsenal started!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then   
+            stock_WAR =
+                {
+                    16610,  5000,       -- (Sword) Wax Sword +1
+                    16716,  5000,       -- (Great Axe) Butterfly Axe +1
+                    16646,  5000,       -- (Axe) Bronze Axe +1
+                    17175,  5000,       -- (Archery) Shortbow +1
+                    17228,  5000,       -- (Marksmanship) Light Crossbow +1
+                    17290,  5000,       -- (Throwing) Coarse Boomerang
+                    4219,   200,        -- (Ammunition) Stone Arrow Quiver
+                    4227,   200,        -- (Ammunition) Bronze Bolt Quiver
+                    12695,  2000,       -- (Gloves) Bronze Mittens +1
+                    12823,  2000,       -- (Legs) Bronze Subligar +1
+                    12951,  2000,       -- (Feet) Bronze Leggings +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13226,  2000,       -- (Waist) Blood Stone +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_WAR =
+                {
+                    16812,  15000,      -- (Sword) War Sword
+                    16718,  15000,      -- (Great Axe) Heavy Axe +1
+                    16664,  15000,      -- (Axe) War Pick +1
+                    17179,  15000,      -- (Archery) Composite Bow +1
+                    17229,  15000,      -- (Marksmanship) Zamburak +1
+                    4222,   2000,       -- (Ammunition) Horn Arrow Quiver
+                    4228,   2000,       -- (Ammunition) Mythril Bolt Quiver
+                    12533,  10000,      -- (Head) Silver Mask +1
+                    12666,  10000,      -- (Body) Silver Mail +1
+                    12772,  10000,      -- (Hands) Silver Mittens +1
+                    12894,  10000,      -- (Legs) Silver Hose +1
+                    13029,  10000,      -- (Feet) Silver Greaves +1
+                    13070,  5000,       -- (Neck) Wolf Gorget +1
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13519,  5000,       -- (Ring) Mythril Ring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_WAR =
+                {
+                    16828,  25000,      -- (Sword) Bastard Sword +1
+                    16731,  25000,      -- (Great Axe) Colossal Axe +1
+                    16682,  25000,      -- (Axe) Darksteel Pick +1
+                    17189,  25000,      -- (Archery) Rapid Bow +1
+                    17227,  25000,      -- (Marksmanship) Heavy Crossbow +1
+                    4224,   5000,       -- (Ammunition) Demon Arrow Quiver
+                    4229,   5000,       -- (Ammunition) Darksteel Bolt Quiver
+                    15225,  50000,      -- (Head) Fighter's Mask +1
+                    14473,  50000,      -- (Body) Fighter's Lorica +1
+                    14890,  50000,      -- (Hands) Fighter's Mufflers +1
+                    15561,  50000,      -- (Legs) Fighter's Cuisses +1
+                    15352,  50000,      -- (Feet) Fighter's Calligae +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13403,  10000,      -- (Earring) Assault Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_WAR =
+                {
+                    18512,  40000,      -- (Great Axe) Dolor Bhuj +1
+                    16662,  40000,      -- (Axe) Doom Tabar +1
+                    18701,  40000,      -- (Archery) Cerberus Bow +1
+                    19266,  40000,      -- (Marksmanship) Darkwing +1
+                    5819,   7500,       -- (Ammunition) Antlion Arrow Quiver
+                    5821,   7500,       -- (Ammunition) Fusion Bolt Quiver
+                    11064,  50000,      -- (Head) Ravager's Mask +2
+                    11084,  50000,      -- (Body) Ravager's Lorica +2
+                    11104,  50000,      -- (Hands) Ravager's Mufflers +2
+                    11124,  50000,      -- (Legs) Ravager's Cuisses +2
+                    11144,  50000,      -- (Feet) Ravager's Calligae +2
+                    11591,  50000,      -- (Neck) Ravager's Gorget
+                    11703,  50000,      -- (Earring) Ravager's Earring
+                    19253,  50000,      -- (Ammunition) Ravager's Orb
+                    10650,  50000,      -- (Head) Warrior's Mask +2
+                    10670,  50000,      -- (Body) Warrior's Lorica +2
+                    10690,  50000,      -- (Hands) Warrior's Mufflers +2
+                    10710,  50000,      -- (Legs) Warrior's Cuisses +2
+                    10730,  50000,      -- (Feet) Warrior's Calligae +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11678,  30000,      -- (Earring) Flame Earring
+                    14630,  30000,      -- (Ring) Flame Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_WAR =
+                {
+                    18916,  300000,     -- (Sword) Heimdall's Doom
+                    20879,  100000,     -- (Great Axe) Nohkux Axe +1
+                    20832,  65000,      -- (Axe) Aalak' Axe +1
+                    19785,  100000,     -- (Archery) Lanner Bow +1
+                    19266,  40000,      -- (Marksmanship) Darkwing +1
+                    6137,   11500,      -- (Ammunition) Chapuli Arrow Quiver
+                    6141,   11500,      -- (Ammunition) Oxidant Bolt Quiver
+                    10442,  300000,     -- (Head) Laeradr Helm
+                    10280,  300000,     -- (Body) Laeradr Breastplate
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11064,  50000,      -- (Head) Ravager's Mask +2
+                    11084,  50000,      -- (Body) Ravager's Lorica +2
+                    11104,  50000,      -- (Hands) Ravager's Mufflers +2
+                    11124,  50000,      -- (Legs) Ravager's Cuisses +2
+                    11144,  50000,      -- (Feet) Ravager's Calligae +2
+                    11591,  50000,      -- (Neck) Ravager's Gorget
+                    11703,  50000,      -- (Earring) Ravager's Earring
+                    19253,  50000,      -- (Ammunition) Ravager's Orb
+                    10650,  50000,      -- (Head) Warrior's Mask +2
+                    10670,  50000,      -- (Body) Warrior's Lorica +2
+                    10690,  50000,      -- (Hands) Warrior's Mufflers +2
+                    10710,  50000,      -- (Legs) Warrior's Cuisses +2
+                    10730,  50000,      -- (Feet) Warrior's Calligae +2
+                    -- 25417,   50000,      -- (Neck) Warrior's Bead Necklace
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_WAR)
+    elseif (job == xi.job.MNK) then
+        local stock_MNK = {}
+        player:PrintToPlayer(string.format("Andreine : Ah, the supreme focus of a Monk! I wish I could focus like you..."),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_MNK =
+                {
+                    20533,  5000,       -- (Hand-to-Hand) Worm Feelers +1
+                    16690,  5000,       -- (Hand-to-Hand) Cesti +1
+                    17296,  1,          -- (Throwing) Pebble
+                    12695,  2000,       -- (Gloves) Bronze Mittens +1
+                    12823,  2000,       -- (Legs) Bronze Subligar +1
+                    12951,  2000,       -- (Feet) Bronze Leggings +1
+                    13060,  2000,       -- (Neck) Feather Collar +1
+                    13184,  5000,       -- (Waist) White Belt
+                    13201,  12000,       -- (Waist) Purple Belt
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_MNK =
+                {
+                    16445,  15000,      -- (Hand-to-Hand) Claws +1
+                    17298,  20,         -- (Ammunition) Tathlum
+                    12539,  10000,      -- (Head) Soil Hachimaki +1
+                    12671,  10000,      -- (Body) Soil Gi +1
+                    12781,  10000,      -- (Hands) Soil Tekko +1
+                    12905,  10000,      -- (Legs) Soil Sitabaki +1
+                    13035,  10000,      -- (Feet) Soil Kyahan +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13202,  30000,      -- (Waist) Brown Belt
+                    13575,  5000,       -- (Back) Ram Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13519,  5000,       -- (Ring) Mythril Ring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_MNK =
+                {
+                    18751,  25000,      -- (Hand-to-Hand) Black Adargas +1
+                    17299,  50,         -- (Ammunition) Astragalos
+                    15226,  50000,      -- (Head) Temple Crown +1
+                    14474,  50000,      -- (Body) Temple Cyclas +1
+                    14891,  50000,      -- (Hands) Temple Gloves +1
+                    15562,  50000,      -- (Legs) Temple Hose +1
+                    15353,  50000,      -- (Feet) Temple Gaiters +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    13186,  75000,      -- (Waist) Black Belt
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13369,  10000,      -- (Earring) Spike Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_MNK =
+                {
+                    18775,  40000,      -- (Hand-to-Hand) Savate Fists +1
+                    19249,  20000,      -- (Ammunition) Thew Bomblet
+                    11065,  50000,      -- (Head) Tantra Crown +2
+                    11085,  50000,      -- (Body) Tantra Cyclas +2
+                    11105,  50000,      -- (Hands) Tantra Gloves +2
+                    11125,  50000,      -- (Legs) Tantra Hose +2
+                    11145,  50000,      -- (Feet) Tantra Gaiters +2
+                    11592,  50000,      -- (Neck) Tantra Necklace
+                    11704,  50000,      -- (Earring) Tantra Earring
+                    19254,  50000,      -- (Ammunition) Tantra Tathlum
+                    10651,  50000,      -- (Head) Melee Crown +2
+                    10671,  50000,      -- (Body) Melee Cyclas +2
+                    10691,  50000,      -- (Hands) Melee Gloves +2
+                    10711,  50000,      -- (Legs) Melee Hose +2
+                    10731,  50000,      -- (Feet) Melee Gaiters +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    13186,  75000,      -- (Waist) Black Belt
+                    11678,  30000,      -- (Earring) Flame Earring
+                    14630,  30000,      -- (Ring) Flame Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_MNK =
+                {
+                    20552,  100000,     -- (Hand-to-Hand) Akua Sainti +1
+                    19249,  20000,      -- (Ammunition) Thew Bomblet
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11065,  50000,      -- (Head) Tantra Crown +2
+                    11085,  50000,      -- (Body) Tantra Cyclas +2
+                    11105,  50000,      -- (Hands) Tantra Gloves +2
+                    11125,  50000,      -- (Legs) Tantra Hose +2
+                    11145,  50000,      -- (Feet) Tantra Gaiters +2
+                    11592,  50000,      -- (Neck) Tantra Necklace
+                    11704,  50000,      -- (Earring) Tantra Earring
+                    19254,  50000,      -- (Ammunition) Tantra Tathlum
+                    10651,  50000,      -- (Head) Melee Crown +2
+                    10671,  50000,      -- (Body) Melee Cyclas +2
+                    10691,  50000,      -- (Hands) Melee Gloves +2
+                    10711,  50000,      -- (Legs) Melee Hose +2
+                    10731,  50000,      -- (Feet) Melee Gaiters +2
+                    -- 25423,   50000,      -- (Neck) Monk's Nodowa
+                    13186,  75000,      -- (Waist) Black Belt
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_MNK)
+    elseif (job == xi.job.WHM) then
+        local stock_WHM = {}
+        player:PrintToPlayer(string.format("Andreine : Hopefully this gear will make leveling White Mage just a little less painful!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_WHM =
+                {
+                    17087,  5000,       -- (Club) Maple Wand +1
+                    17137,  5000,       -- (Club) Ash Club +1
+                    17144,  5000,       -- (Club) Bronze Hammer +1
+                    17123,  5000,       -- (Staff) Ash Staff +1
+                    17122,  5000,       -- (Staff) Ash Pole +1
+                    12744,  2000,       -- (Gloves) Cuffs +1
+                    12897,  2000,       -- (Legs) Slops +1
+                    12983,  2000,       -- (Feet) Ash Clogs +1
+                    13093,  2000,       -- (Neck) Justice Badge
+                    13190,  2000,       -- (Waist) Heko Obi +1
+                    13605,  2000,       -- (Back) Cape +1
+                    14694,  2000,       -- (Earring) Energy Earring +1
+                    13440,  2000,       -- (Ring) Ascetic's Ring
+                    13548,  50000,      -- (Ring) Astral Ring
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_WHM =
+                {
+                    17141,  15000,      -- (Club) Solid Wand
+                    17409,  15000,      -- (Club) Mythril Rod +1
+                    17121,  15000,      -- (Club) Maul +1
+                    17534,  15000,      -- (Staff) Whale Staff +1
+                    17119,  15000,      -- (Staff) Elm Pole +1
+                    18137,  5000,       -- (Ammunition) Holy Ampulla
+                    12538,  10000,      -- (Head) Red Cap +1
+                    12625,  10000,      -- (Body) Gambison +1
+                    12779,  10000,      -- (Hands) Bracers +1
+                    12903,  10000,      -- (Legs) Hose +1
+                    13034,  10000,      -- (Feet) Socks +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13233,  5000,       -- (Waist) Gold Obi +1
+                    13618,  5000,       -- (Back) White Cape +1
+                    14702,  5000,       -- (Earring) Aura Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_WHM =
+                {
+                    17427,  25000,      -- (Club) Ebony Wand +1
+                    17435,  25000,      -- (Club) Darksteel Rod +1
+                    17432,  25000,      -- (Club) Darksteel Maul +1
+                    17520,  25000,      -- (Staff) Heavy Staff +1
+                    17521,  25000,      -- (Staff) Mahogany Pole +1
+                    15227,  50000,      -- (Head) Healer's Cap +1
+                    14475,  50000,      -- (Body) Healer's Briault +1
+                    14892,  50000,      -- (Hands) Healer's Mitts +1
+                    15563,  50000,      -- (Legs) Healer's Pantaloons +1
+                    15354,  50000,      -- (Feet) Healer's Duckbills +1
+                    15887,  10000,      -- (Neck) Resolute Belt
+                    15885,  10000,      -- (Neck) Spectral Belt
+                    15490,  10000,      -- (Back) Miraculous Cape
+                    15971,  10000,      -- (Earring) Antivenom Earring
+                    15972,  10000,      -- (Earring) Insomnia Earring
+                    15776,  10000,      -- (Ring) Ebullient Ring
+                    15777,  10000,      -- (Ring) Hale Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_WHM =
+                {
+                    18874,  40000,      -- (Club) Brise-os +1
+                    17568,  40000,      -- (Staff) Eight-sided Pole +1
+                    17277,  20000,      -- (Ammunition) Hedgehog Bomb
+                    11066,  50000,      -- (Head) Orison Cap +2
+                    11086,  50000,      -- (Body) Orison Bliaud +2
+                    11106,  50000,      -- (Hands) Orison Mitts +2
+                    11126,  50000,      -- (Legs) Orison Pantaloons +2
+                    11146,  50000,      -- (Feet) Orison Duckbills +2
+                    11615,  50000,      -- (Neck) Orison Locket
+                    11705,  50000,      -- (Earring) Orison Earring
+                    11554,  50000,      -- (Back) Orison Cape
+                    10652,  50000,      -- (Head) Cleric's Cap +2
+                    10672,  50000,      -- (Body) Cleric's Briault +2
+                    10692,  50000,      -- (Hands) Cleric's Mitts +2
+                    10712,  50000,      -- (Legs) Cleric's Pantaloons +2
+                    10732,  50000,      -- (Feet) Cleric's Duckbills +2
+                    11579,  30000,      -- (Neck) Fylgja Torque
+                    15949,  30000,      -- (Waist) Pythia Sash +1
+                    27598,  30000,      -- (Back) Dew Silk Cape +1
+                    11683,  30000,      -- (Earring) Aqua Earring
+                    13308,  30000,      -- (Ring) Communion Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_WHM =
+                {
+                    21133,  100000,     -- (Club) Sasah Wand +1
+                    21132,  100000,     -- (Club) Aedold
+                    21208,  100000,     -- (Staff) Lehbrailg
+                    19780,  30000,      -- (Ammunition) Mana Ampulla
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11066,  50000,      -- (Head) Orison Cap +2
+                    11086,  50000,      -- (Body) Orison Bliaud +2
+                    11106,  50000,      -- (Hands) Orison Mitts +2
+                    11126,  50000,      -- (Legs) Orison Pantaloons +2
+                    11146,  50000,      -- (Feet) Orison Duckbills +2
+                    11615,  50000,      -- (Neck) Orison Locket
+                    11705,  50000,      -- (Earring) Orison Earring
+                    11554,  50000,      -- (Back) Orison Cape
+                    10652,  50000,      -- (Head) Cleric's Cap +2
+                    10672,  50000,      -- (Body) Cleric's Briault +2
+                    10692,  50000,      -- (Hands) Cleric's Mitts +2
+                    10712,  50000,      -- (Legs) Cleric's Pantaloons +2
+                    10732,  50000,      -- (Feet) Cleric's Duckbills +2
+                    -- 25429,   50000,      -- (Neck) Cleric's Torque
+                    28455,  50000,      -- (Waist) Ovate Rope
+                    28596,  50000,      -- (Back) Oretania's Cape +1
+                    -- 28474,   50000,      -- (Earring) Mendicant's Earring
+                    -- 11054,   50000,      -- (Earring) Pensee Earring
+                    11683,  30000,      -- (Earring) Aqua Earring
+                    -- 27566,   50000,      -- (Ring) Leviathan Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_WHM)
+    elseif (job == xi.job.BLM) then
+        local stock_BLM = {}
+        player:PrintToPlayer(string.format("Andreine : Hmm, do you really need extra gear as a Black Mage? So overpowered!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_BLM =
+                {
+                    17087,  5000,       -- (Club) Maple Wand +1
+                    17123,  5000,       -- (Staff) Ash Staff +1
+                    12744,  2000,       -- (Gloves) Cuffs +1
+                    12897,  2000,       -- (Legs) Slops +1
+                    12983,  2000,       -- (Feet) Ash Clogs +1
+                    13093,  2000,       -- (Neck) Justice Badge
+                    13190,  2000,       -- (Waist) Heko Obi +1
+                    13605,  2000,       -- (Back) Cape +1
+                    14694,  2000,       -- (Earring) Energy Earring +1
+                    13475,  2000,       -- (Ring) Hermit's Ring
+                    13548,  50000,      -- (Ring) Astral Ring
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_BLM =
+                {
+                    17141,  15000,      -- (Club) Solid Wand
+                    17409,  15000,      -- (Club) Mythril Rod +1
+                    17534,  15000,      -- (Staff) Whale Staff +1
+                    17119,  15000,      -- (Staff) Elm Pole +1
+                    15173,  10000,      -- (Head) Kosshin
+                    13730,  10000,      -- (Body) Frost Robe
+                    12750,  10000,      -- (Hands) New Moon Armlets
+                    12904,  10000,      -- (Legs) Linen Slacks +1
+                    13040,  10000,      -- (Feet) Shoes +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13233,  5000,       -- (Waist) Gold Obi +1
+                    13610,  5000,       -- (Back) Black Cape +1
+                    14702,  5000,       -- (Earring) Aura Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_BLM =
+                {
+                    17427,  25000,      -- (Club) Ebony Wand +1
+                    17435,  25000,      -- (Club) Darksteel Rod +1
+                    17520,  25000,      -- (Staff) Heavy Staff +1
+                    17521,  25000,      -- (Staff) Mahogany Pole +1
+                    15228,  50000,      -- (Head) Wizard's Petasos +1
+                    14476,  50000,      -- (Body) Wizard's Coat +1
+                    14893,  50000,      -- (Hands) Wizard's Gloves +1
+                    15564,  50000,      -- (Legs) Wizard's Tonban +1
+                    15355,  50000,      -- (Feet) Wizard's Sabots +1
+                    15887,  10000,      -- (Neck) Resolute Belt
+                    15885,  10000,      -- (Neck) Spectral Belt
+                    15490,  10000,      -- (Back) Miraculous Cape
+                    15971,  10000,      -- (Earring) Antivenom Earring
+                    15972,  10000,      -- (Earring) Insomnia Earring
+                    15776,  10000,      -- (Ring) Ebullient Ring
+                    15777,  10000,      -- (Ring) Hale Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_BLM =
+                {
+                    17118,  40000,      -- (Staff) Lituus +1
+                    17277,  20000,      -- (Ammunition) Hedgehog Bomb
+                    11067,  50000,      -- (Head) Goetia Petasos +2
+                    11087,  50000,      -- (Body) Goetia Coat +2
+                    11107,  50000,      -- (Hands) Goetia Gloves +2
+                    11127,  50000,      -- (Legs) Goetia Chausses +2
+                    11147,  50000,      -- (Feet) Goetia Sabots +2
+                    11593,  50000,      -- (Neck) Goetia Chain
+                    11706,  50000,      -- (Earring) Goetia Earring
+                    16203,  50000,      -- (Back) Goetia Mantle
+                    10653,  50000,      -- (Head) Sorcerer's Petasos +2
+                    10673,  50000,      -- (Body) Sorcerer's Coat +2
+                    10693,  50000,      -- (Hands) Sorcerer's Gloves +2
+                    10713,  50000,      -- (Legs) Sorcerer's Tonban +2
+                    10733,  50000,      -- (Feet) Sorcerer's Sabots +2
+                    11584,  30000,      -- (Neck) Lemegeton Medallion +1
+                    11743,  30000,      -- (Waist) Searing Sash
+                    11560,  30000,      -- (Back) Pedant Cape
+                    11682,  30000,      -- (Earring) Snow Earring
+                    13306,  30000,      -- (Ring) Omniscient Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_BLM =
+                {
+                    21133,  100000,     -- (Club) Sasah Wand +1
+                    21208,  100000,     -- (Staff) Lehbrailg
+                    -- 21362,   30000,      -- (Ammunition) Ombre Tathlum +1
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11067,  50000,      -- (Head) Goetia Petasos +2
+                    11087,  50000,      -- (Body) Goetia Coat +2
+                    11107,  50000,      -- (Hands) Goetia Gloves +2
+                    11127,  50000,      -- (Legs) Goetia Chausses +2
+                    11147,  50000,      -- (Feet) Goetia Sabots +2
+                    11593,  50000,      -- (Neck) Goetia Chain
+                    11706,  50000,      -- (Earring) Goetia Earring
+                    16203,  50000,      -- (Back) Goetia Mantle
+                    10653,  50000,      -- (Head) Sorcerer's Petasos +2
+                    10673,  50000,      -- (Body) Sorcerer's Coat +2
+                    10693,  50000,      -- (Hands) Sorcerer's Gloves +2
+                    10713,  50000,      -- (Legs) Sorcerer's Tonban +2
+                    10733,  50000,      -- (Feet) Sorcerer's Sabots +2
+                    -- 25435,   50000,      -- (Neck) Sorcerer's Stole
+                    10839,  50000,      -- (Waist) Othila Sash
+                    28601,  50000,      -- (Back) Seshaw Cape
+                    11682,  30000,      -- (Earring) Snow Earring
+                    -- 27574,   50000,      -- (Ring) Shiva Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_BLM)
+    elseif (job == xi.job.RDM) then
+        local stock_RDM = {}
+        player:PrintToPlayer(string.format("Andreine : Couldn't pick just one school of magic to focus on eh? That's ok, I've got gear for you!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_RDM =
+                {
+                    16610,  5000,       -- (Sword) Wax Sword +1
+                    17087,  5000,       -- (Club) Maple Wand +1
+                    12744,  2000,       -- (Gloves) Cuffs +1
+                    12897,  2000,       -- (Legs) Slops +1
+                    12983,  2000,       -- (Feet) Ash Clogs +1
+                    13093,  2000,       -- (Neck) Justice Badge
+                    13190,  2000,       -- (Waist) Heko Obi +1
+                    13605,  2000,       -- (Back) Cape +1
+                    14694,  2000,       -- (Earring) Energy Earring +1
+                    13440,  2000,       -- (Ring) Ascetic's Ring
+                    13475,  2000,       -- (Ring) Hermit's Ring
+                    13548,  50000,      -- (Ring) Astral Ring
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_RDM =
+                {
+                    16815,  15000,      -- (Sword) Mythril Degen +1
+                    12335,  10000,      -- (Shield) Targe +1
+                    17141,  15000,      -- (Club) Solid Wand
+                    17534,  15000,      -- (Staff) Whale Staff +1
+                    12538,  10000,      -- (Head) Red Cap +1
+                    12625,  10000,      -- (Body) Gambison +1
+                    12779,  10000,      -- (Hands) Bracers +1
+                    12903,  10000,      -- (Legs) Hose +1
+                    13034,  10000,      -- (Feet) Socks +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13233,  5000,       -- (Waist) Gold Obi +1
+                    13611,  7500,       -- (Back) Red Cape +1
+                    14702,  5000,       -- (Earring) Aura Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_RDM =
+                {
+                    17641,  25000,      -- (Sword) Gold Sword +1
+                    12353,  25000,      -- (Shield) Gilt Buckler
+                    17427,  25000,      -- (Club) Ebony Wand +1
+                    17520,  25000,      -- (Staff) Heavy Staff +1
+                    15229,  50000,      -- (Head) Warlock's Chapeau +1
+                    14477,  50000,      -- (Body) Warlock's Tabard +1
+                    14894,  50000,      -- (Hands) Warlock's Gloves +1
+                    15565,  50000,      -- (Legs) Warlock's Tights +1
+                    15356,  50000,      -- (Feet) Warlock's Boots +1
+                    15887,  10000,      -- (Neck) Resolute Belt
+                    15885,  10000,      -- (Neck) Spectral Belt
+                    15490,  10000,      -- (Back) Miraculous Cape
+                    15971,  10000,      -- (Earring) Antivenom Earring
+                    15972,  10000,      -- (Earring) Insomnia Earring
+                    15776,  10000,      -- (Ring) Ebullient Ring
+                    15777,  10000,      -- (Ring) Hale Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_RDM =
+                {
+                    17664,  40000,      -- (Sword) Firmament +1
+                    12386,  40000,      -- (Shield) Acheron Shield +1
+                    17277,  20000,      -- (Ammunition) Hedgehog Bomb
+                    11068,  50000,      -- (Head) Estoqueur's Chappel +2
+                    11088,  50000,      -- (Body) Estoqueur's Sayon +2
+                    11108,  50000,      -- (Hands) Estoqueur's Gantherots +2
+                    11128,  50000,      -- (Legs) Estoqueur's Fuseau +2
+                    11148,  50000,      -- (Feet) Estoqueur's Houseaux +2
+                    11594,  50000,      -- (Neck) Estoqueur's Collar
+                    11707,  50000,      -- (Earring) Estoqueur's Earring
+                    16204,  50000,      -- (Back) Estoqueur's Cape
+                    10654,  50000,      -- (Head) Duelist's Chapeau +2
+                    10674,  50000,      -- (Body) Duelist's Tabard +2
+                    10694,  50000,      -- (Hands) Duelist's Gloves +2
+                    10714,  50000,      -- (Legs) Duelist's Tights +2
+                    10734,  50000,      -- (Feet) Duelist's Boots +2
+                    11579,  30000,      -- (Neck) Fylgja Torque
+                    11584,  30000,      -- (Neck) Lemegeton Medallion +1
+                    11747,  30000,      -- (Waist) Austerity Belt
+                    16210,  30000,      -- (Back) Ebullient Cape
+                    16052,  30000,      -- (Earring) Incubus Earring
+                    11683,  30000,      -- (Earring) Aqua Earring
+                    11682,  30000,      -- (Earring) Snow Earring
+                    13308,  30000,      -- (Ring) Communion Ring
+                    13306,  30000,      -- (Ring) Omniscient Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_RDM =
+                {
+                    20743,  100000,     -- (Sword) Bihkah Sword +1
+                    28668,  100000,     -- (Shield) Matamata Shield +1
+                    21207,  100000,     -- (Staff) Hemolele Staff +1
+                    -- 21362,   30000,      -- (Ammunition) Ombre Tathlum +1
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11068,  50000,      -- (Head) Estoqueur's Chappel +2
+                    11088,  50000,      -- (Body) Estoqueur's Sayon +2
+                    11108,  50000,      -- (Hands) Estoqueur's Gantherots +2
+                    11128,  50000,      -- (Legs) Estoqueur's Fuseau +2
+                    11148,  50000,      -- (Feet) Estoqueur's Houseaux +2
+                    11594,  50000,      -- (Neck) Estoqueur's Collar
+                    11707,  50000,      -- (Earring) Estoqueur's Earring
+                    16204,  50000,      -- (Back) Estoqueur's Cape
+                    10654,  50000,      -- (Head) Duelist's Chapeau +2
+                    10674,  50000,      -- (Body) Duelist's Tabard +2
+                    10694,  50000,      -- (Hands) Duelist's Gloves +2
+                    10714,  50000,      -- (Legs) Duelist's Tights +2
+                    10734,  50000,      -- (Feet) Duelist's Boots +2
+                    -- 25441,   50000,      -- (Neck) Duelist's Torque
+                    10839,  50000,      -- (Waist) Othila Sash
+                    28455,  50000,      -- (Waist) Ovate Rope
+                    28596,  50000,      -- (Back) Oretania's Cape +1
+                    28601,  50000,      -- (Back) Seshaw Cape
+                    11683,  30000,      -- (Earring) Aqua Earring
+                    11682,  30000,      -- (Earring) Snow Earring
+                    -- 27566,   50000,      -- (Ring) Leviathan Ring
+                    -- 27574,   50000,      -- (Ring) Shiva Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_RDM)
+    elseif (job == xi.job.THF) then
+        local stock_THF = {}
+        player:PrintToPlayer(string.format("Andreine : Please keep in mind that my wares are for sale and not lifting by sticky fingers!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_THF =
+                {
+                    16610,  5000,       -- (Sword) Wax Sword +1
+                    16690,  5000,       -- (Hand-to-Hand) Cesti +1
+                    16491,  5000,       -- (Dagger) Bronze Knife +1
+                    16492,  5000,       -- (Dagger) Bronze Dagger +1
+                    17175,  5000,       -- (Archery) Shortbow +1
+                    19225,  5000,       -- (Marksmanship) Musketoon +1
+                    17290,  5000,       -- (Throwing) Coarse Boomerang
+                    4219,   200,        -- (Ammunition) Stone Arrow Quiver
+                    5359,   200,        -- (Ammunition) Bronze Bullet Pouch
+                    12695,  2000,       -- (Gloves) Bronze Mittens +1
+                    12823,  2000,       -- (Legs) Bronze Subligar +1
+                    12951,  2000,       -- (Feet) Bronze Leggings +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_THF =
+                {
+                    19106,  10000,      -- (Dagger) Thug's Jambiya +1
+                    17260,  15000,      -- (Marksmanship) Pirate's Gun +1
+                    5363,   2000,       -- (Ammunition) Bullet Pouch
+                    12538,  10000,      -- (Head) Red Cap +1
+                    12625,  10000,      -- (Body) Gambison +1
+                    12779,  10000,      -- (Hands) Bracers +1
+                    12903,  10000,      -- (Legs) Hose +1
+                    13034,  10000,      -- (Feet) Socks +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_THF =
+                {
+                    17603,  15000,      -- (Dagger) Cermet Kukri +1
+                    19227,  25000,      -- (Marksmanship) Blunderbuss +1
+                    5353,   5000,       -- (Ammunition) Iron Bullet Pouch
+                    15230,  50000,      -- (Head) Rogue's Bonnet +1
+                    14478,  50000,      -- (Body) Rogue's Vest +1
+                    14895,  50000,      -- (Hands) Rogue's Armlets +1
+                    15566,  50000,      -- (Legs) Rogue's Culottes +1
+                    15357,  50000,      -- (Feet) Rogue's Poulaines +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13369,  10000,      -- (Earring) Spike Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_THF =
+                {
+                    16481,  35000,      -- (Dagger) Yataghan +1
+                    17252,  40000,      -- (Marksmanship) Culverin
+                    5353,   5000,       -- (Ammunition) Iron Bullet Pouch
+                    17342,  75,         -- (Ammunition) Cannon Shell
+                    11069,  50000,      -- (Head) Raider's Bonnet +2
+                    11089,  50000,      -- (Body) Raider's Vest +2
+                    11109,  50000,      -- (Hands) Raider's Armlets +2
+                    11129,  50000,      -- (Legs) Raider's Culottes +2
+                    11149,  50000,      -- (Feet) Raider's Poulaines +2 (TH)
+                    19260,  50000,      -- (Throwing) Raider's Boomerang
+                    11708,  50000,      -- (Earring) Raider's Earring
+                    11736,  50000,      -- (Waist) Raider's Belt
+                    10655,  50000,      -- (Head) Assassin's Bonnet +2
+                    10675,  50000,      -- (Body) Assassin's Vest +2
+                    10695,  50000,      -- (Hands) Assassin's Armlets +2 (TH)
+                    10715,  50000,      -- (Legs) Assassin's Culottes +2
+                    10735,  50000,      -- (Feet) Assassin's Poulaines +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11681,  30000,      -- (Earring) Breeze Earring
+                    11679,  30000,      -- (Earring) Thunder Earring
+                    14636,  30000,      -- (Ring) Breeze Ring
+                    14638,  30000,      -- (Ring) Thunder Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_THF =
+                {
+                    20642,  65000,      -- (Dagger) Tzustes Knife +1
+                    19742,  100000,     -- (Marksmanship) Handgonne +1
+                    5353,   5000,       -- (Ammunition) Iron Bullet Pouch
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11069,  50000,      -- (Head) Raider's Bonnet +2
+                    11089,  50000,      -- (Body) Raider's Vest +2
+                    11109,  50000,      -- (Hands) Raider's Armlets +2
+                    11129,  50000,      -- (Legs) Raider's Culottes +2
+                    11149,  50000,      -- (Feet) Raider's Poulaines +2 (TH)
+                    19260,  50000,      -- (Throwing) Raider's Boomerang
+                    11708,  50000,      -- (Earring) Raider's Earring
+                    11736,  50000,      -- (Waist) Raider's Belt
+                    10655,  50000,      -- (Head) Assassin's Bonnet +2
+                    10675,  50000,      -- (Body) Assassin's Vest +2
+                    10695,  50000,      -- (Hands) Assassin's Armlets +2 (TH)
+                    10715,  50000,      -- (Legs) Assassin's Culottes +2
+                    10735,  50000,      -- (Feet) Assassin's Poulaines +2
+                    -- 25447,   50000,      -- (Neck) Assassin's Gorget
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_THF)
+    elseif (job == xi.job.PLD) then
+        local stock_PLD = {}
+        player:PrintToPlayer(string.format("Andreine : You're going to need to soak up a lot of damage as a Paladin! I hope this gear helps!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_PLD =
+                {
+                    16627,  5000,       -- (Sword) Spatha +1
+                    12371,  5000,       -- (Shield) Clipeus
+                    17175,  5000,       -- (Archery) Shortbow +1
+                    4219,   200,        -- (Ammunition) Stone Arrow Quiver
+                    12784,  2000,       -- (Gloves) Leather Gloves +1
+                    12908,  2000,       -- (Legs) Leather Trousers +1
+                    12971,  2000,       -- (Feet) Leather Highboots +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    14670,  2000,       -- (Ring) Safeguard Ring
+                    13548,  50000,      -- (Ring) Astral Ring
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_PLD =
+                {
+                    16812,  15000,      -- (Sword) War Sword
+                    12335,  10000,      -- (Shield) Targe +1
+                    17179,  15000,      -- (Archery) Composite Bow +1
+                    4222,   2000,       -- (Ammunition) Horn Arrow Quiver
+                    12533,  10000,      -- (Head) Silver Mask +1
+                    12666,  10000,      -- (Body) Silver Mail +1
+                    12772,  10000,      -- (Hands) Silver Mittens +1
+                    12894,  10000,      -- (Legs) Silver Hose +1
+                    13029,  10000,      -- (Feet) Silver Greaves +1
+                    13070,  5000,       -- (Neck) Wolf Gorget +1
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13506,  5000,       -- (Ring) Bomb Ring
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_PLD =
+                {
+                    17641,  25000,      -- (Sword) Gold Sword +1
+                    12353,  25000,      -- (Shield) Gilt Buckler
+                    17189,  25000,      -- (Archery) Rapid Bow +1
+                    4224,   5000,       -- (Ammunition) Demon Arrow Quiver
+                    15231,  50000,      -- (Head) Gallant Coronet +1
+                    14479,  50000,      -- (Body) Gallant Surcoat +1
+                    14896,  50000,      -- (Hands) Gallant Gauntlets +1
+                    15567,  50000,      -- (Legs) Gallant Breeches +1
+                    15358,  50000,      -- (Feet) Gallant Leggings +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15887,  10000,      -- (Waist) Resolute Belt
+                    13691,  10000,      -- (Back) Knightly Mantle
+                    14758,  10000,      -- (Earring) Knightly Earring
+                    16009,  10000,      -- (Earring) Pennon Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_PLD =
+                {
+                    17664,  40000,      -- (Sword) Firmament +1
+                    16163,  40000,      -- (Shield) Januwiyah +1
+                    18682,  40000,      -- (Archery) Lamian Kaman +1
+                    5819,   7500,       -- (Ammunition) Antlion Arrow Quiver
+                    11070,  50000,      -- (Head) Creed Armet +2
+                    11090,  50000,      -- (Body) Creed Cuirass +2
+                    11110,  50000,      -- (Hands) Creed Gauntlets +2
+                    11130,  50000,      -- (Legs) Creed Cuisses +2
+                    11150,  50000,      -- (Feet) Creed Sabatons +2
+                    11595,  50000,      -- (Neck) Creed Collar
+                    11709,  50000,      -- (Earring) Creed Earring
+                    11750,  50000,      -- (Waist) Creed Baudrier
+                    10656,  50000,      -- (Head) Valor Coronet +2
+                    10676,  50000,      -- (Body) Valor Surcoat +2
+                    10696,  50000,      -- (Hands) Valor Gauntlets +2
+                    10716,  50000,      -- (Legs) Valor Breeches +2
+                    10736,  50000,      -- (Feet) Valor Leggings +2
+                    10929,  30000,      -- (Neck) Apathy Gorget
+                    15895,  30000,      -- (Waist) Trance Belt (AH price)
+                    16216,  30000,      -- (Back) Cerberus Mantle +1
+                    11680,  30000,      -- (Earring) Soil Earring
+                    14634,  30000,      -- (Ring) Soil Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_PLD =
+                {
+                    20743,  100000,     -- (Sword) Bihkah Sword +1
+                    28668,  100000,     -- (Shield) Matamata Shield +1
+                    19785,  100000,     -- (Archery) Lanner Bow +1
+                    6137,   11500,      -- (Ammunition) Chapuli Arrow Quiver
+                    10442,  300000,     -- (Head) Laeradr Helm
+                    10280,  300000,     -- (Body) Laeradr Breastplate
+                    10435,  100000,     -- (Head) Dux Visor +1
+                    10273,  100000,     -- (Body) Dux Scale Mail +1
+                    10317,  100000,     -- (Hands) Dux Finger Gauntlets +1
+                    10347,  100000,     -- (Legs) Dux Cuisses +1
+                    10364,  100000,     -- (Feet) Dux Greaves +1
+                    11070,  50000,      -- (Head) Creed Armet +2
+                    11090,  50000,      -- (Body) Creed Cuirass +2
+                    11110,  50000,      -- (Hands) Creed Gauntlets +2
+                    11130,  50000,      -- (Legs) Creed Cuisses +2
+                    11150,  50000,      -- (Feet) Creed Sabatons +2
+                    11595,  50000,      -- (Neck) Creed Collar
+                    11709,  50000,      -- (Earring) Creed Earring
+                    11750,  50000,      -- (Waist) Creed Baudrier
+                    10656,  50000,      -- (Head) Valor Coronet +2
+                    10676,  50000,      -- (Body) Valor Surcoat +2
+                    10696,  50000,      -- (Hands) Valor Gauntlets +2
+                    10716,  50000,      -- (Legs) Valor Breeches +2
+                    10736,  50000,      -- (Feet) Valor Leggings +2
+                    -- 25453,   50000,      -- (Neck) Knight's Bead Necklace
+                    10819,  50000,      -- (Waist) Flume Belt
+                    10996,  50000,      -- (Back) Testudo Mantle
+                    11050,  50000,      -- (Earring) Puissant Pearl
+                    11039,  50000,      -- (Earring) Brachyura Earring
+                    10798,  50000,      -- (Ring) Eihwaz Ring
+                    28577,  50000,      -- (Ring) Kunaji Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_PLD)
+    elseif (job == xi.job.DRK) then
+        local stock_DRK = {}
+        player:PrintToPlayer(string.format("Andreine : I know you're always hungry for more souls as a Dark Knight but don't forget to eat food too!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_DRK =
+                {
+                    16778,  5000,       -- (Scythe) Bronze Zaghnal +1
+                    16606,  5000,       -- (Great Sword) Rusty Greatsword
+                    16637,  5000,       -- (Great Sword) Deathbringer
+                    16716,  5000,       -- (Great Axe) Butterfly Axe +1
+                    17228,  5000,       -- (Marksmanship) Light Crossbow +1
+                    4227,   200,        -- (Ammunition) Bronze Bolt Quiver
+                    12784,  2000,       -- (Gloves) Leather Gloves +1
+                    12908,  2000,       -- (Legs) Leather Trousers +1
+                    12971,  2000,       -- (Feet) Leather Highboots +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_DRK =
+                {
+                    16797,  15000,      -- (Scythe) Mythril Zaghnal +1
+                    16936,  15000,      -- (Great Sword) Demonic Sword
+                    17229,  15000,      -- (Marksmanship) Zamburak +1
+                    4228,   2000,       -- (Ammunition) Mythril Bolt Quiver
+                    12533,  10000,      -- (Head) Silver Mask +1
+                    12666,  10000,      -- (Body) Silver Mail +1
+                    12772,  10000,      -- (Hands) Silver Mittens +1
+                    12894,  10000,      -- (Legs) Silver Hose +1
+                    13029,  10000,      -- (Feet) Silver Greaves +1
+                    13070,  5000,       -- (Neck) Wolf Gorget +1
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13519,  5000,       -- (Ring) Mythril Ring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_DRK =
+                {
+                    16790,  25000,      -- (Scythe) Darksteel Scythe +1
+                    16616,  25000,      -- (Great Sword) Zweihander +1
+                    17227,  25000,      -- (Marksmanship) Heavy Crossbow +1
+                    4229,   5000,       -- (Ammunition) Darksteel Bolt Quiver
+                    15232,  50000,      -- (Head) Chaos Burgeonet +1
+                    14480,  50000,      -- (Body) Chaos Cuirass +1
+                    14897,  50000,      -- (Hands) Chaos Gauntlets +1
+                    15568,  50000,      -- (Legs) Chaos Flanchard +1
+                    15359,  50000,      -- (Feet) Chaos Sollerets +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13403,  10000,      -- (Earring) Assault Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_DRK =
+                {
+                    18965,  40000,      -- (Scythe) Dire Scythe +1
+                    19166,  40000,      -- (Great Sword) Cratus Sword +1
+                    19266,  40000,      -- (Marksmanship) Darkwing +1
+                    5821,   7500,       -- (Ammunition) Fusion Bolt Quiver
+                    11071,  50000,      -- (Head) Bale Burgeonet +2
+                    11091,  50000,      -- (Body) Bale Cuirass +2
+                    11111,  50000,      -- (Hands) Bale Gauntlets +2
+                    11131,  50000,      -- (Legs) Bale Flanchard +2
+                    11151,  50000,      -- (Feet) Bale Sollerets +2
+                    11616,  50000,      -- (Neck) Bale Choker
+                    11710,  50000,      -- (Earring) Bale Earring
+                    11737,  50000,      -- (Waist) Bale Belt
+                    10657,  50000,      -- (Head) Abyss Burgeonet +2
+                    10677,  50000,      -- (Body) Abyss Cuirass +2
+                    10697,  50000,      -- (Hands) Abyss Gauntlets +2
+                    10717,  50000,      -- (Legs) Abyss Flanchard +2
+                    10737,  50000,      -- (Feet) Abyss Sollerets +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11678,  30000,      -- (Earring) Flame Earring
+                    14630,  30000,      -- (Ring) Flame Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_DRK =
+                {
+                    18916,  300000,     -- (Sword) Heimdall's Doom
+                    20923,  100000,     -- (Scythe) Aak'ab Scythe +1
+                    20788,  100000,     -- (Great Sword) Hatzoaar Sword +1
+                    19266,  40000,      -- (Marksmanship) Darkwing +1
+                    6141,   11500,      -- (Ammunition) Oxidant Bolt Quiver
+                    10442,  300000,     -- (Head) Laeradr Helm
+                    10280,  300000,     -- (Body) Laeradr Breastplate
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11071,  50000,      -- (Head) Bale Burgeonet +2
+                    11091,  50000,      -- (Body) Bale Cuirass +2
+                    11111,  50000,      -- (Hands) Bale Gauntlets +2
+                    11131,  50000,      -- (Legs) Bale Flanchard +2
+                    11151,  50000,      -- (Feet) Bale Sollerets +2
+                    11616,  50000,      -- (Neck) Bale Choker
+                    11710,  50000,      -- (Earring) Bale Earring
+                    11737,  50000,      -- (Waist) Bale Belt
+                    10657,  50000,      -- (Head) Abyss Burgeonet +2
+                    10677,  50000,      -- (Body) Abyss Cuirass +2
+                    10697,  50000,      -- (Hands) Abyss Gauntlets +2
+                    10717,  50000,      -- (Legs) Abyss Flanchard +2
+                    10737,  50000,      -- (Feet) Abyss Sollerets +2
+                    -- 25459,   50000,      -- (Neck) Abyssal Bead Necklace
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10819,  50000,      -- (Waist) Flume Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_DRK)
+    elseif (job == xi.job.BST) then
+        local stock_BST = {}
+        player:PrintToPlayer(string.format("Andreine : You're lucky to always have a friend as a Beastmaster! I miss my pets..."),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_BST =
+                {
+                    16646,  5000,       -- (Axe) Bronze Axe +1
+                    16778,  5000,       -- (Scythe) Bronze Zaghnal +1
+                    12695,  2000,       -- (Gloves) Bronze Mittens +1
+                    12823,  2000,       -- (Legs) Bronze Subligar +1
+                    12951,  2000,       -- (Feet) Bronze Leggings +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13072,  2000,       -- (Neck) Bird Whistle
+                    13110,  2000,       -- (Neck) Beast Whistle
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_BST =
+                {
+                    16664,  15000,      -- (Axe) War Pick +1
+                    12335,  10000,      -- (Shield) Targe +1
+                    16797,  15000,      -- (Scythe) Mythril Zaghnal +1
+                    12533,  10000,      -- (Head) Silver Mask +1
+                    12666,  10000,      -- (Body) Silver Mail +1
+                    12772,  10000,      -- (Hands) Silver Mittens +1
+                    12894,  10000,      -- (Legs) Silver Hose +1
+                    13029,  10000,      -- (Feet) Silver Greaves +1
+                    13070,  5000,       -- (Neck) Wolf Gorget +1
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13519,  5000,       -- (Ring) Mythril Ring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_BST =
+                {
+                    16682,  25000,      -- (Axe) Darksteel Pick +1
+                    12353,  25000,      -- (Shield) Gilt Buckler
+                    18962,  25000,      -- (Scythe) Rusty Zaghnal
+                    15233,  50000,      -- (Head) Beast Helm +1
+                    14481,  50000,      -- (Body) Beast Jackcoat +1
+                    14898,  50000,      -- (Hands) Beast Gloves +1
+                    15569,  50000,      -- (Legs) Beast Trousers +1
+                    15360,  50000,      -- (Feet) Beast Gaiters +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13403,  10000,      -- (Earring) Assault Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_BST =
+                {
+                    16662,  40000,      -- (Axe) Doom Tabar +1
+                    12386,  40000,      -- (Shield) Acheron Shield +1
+                    18963,  40000,      -- (Scythe) Gleaming Zaghnal
+                    11072,  50000,      -- (Head) Ferine Cabasset +2
+                    11092,  50000,      -- (Body) Ferine Gausape +2
+                    11112,  50000,      -- (Hands) Ferine Manoplas +2
+                    11132,  50000,      -- (Legs) Ferine Quijotes +2
+                    11152,  50000,      -- (Feet) Ferine Ocreae +2
+                    11617,  50000,      -- (Neck) Ferine Necklace
+                    11711,  50000,      -- (Earring) Ferine Earring
+                    11555,  50000,      -- (Back) Ferine Mantle
+                    10658,  50000,      -- (Head) Monster Helm +2
+                    10678,  50000,      -- (Body) Monster Jackcoat +2
+                    10698,  50000,      -- (Hands) Monster Gloves +2
+                    10718,  50000,      -- (Legs) Monster Trousers +2
+                    10738,  50000,      -- (Feet) Monster Gaiters +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11678,  30000,      -- (Earring) Flame Earring
+                    14630,  30000,      -- (Ring) Flame Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_BST =
+                {
+                    20832,  65000,      -- (Axe) Aalak' Axe +1
+                    28668,  100000,     -- (Shield) Matamata Shield +1
+                    18562,  100000,     -- (Scythe) Yhatdhara +1
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11072,  50000,      -- (Head) Ferine Cabasset +2
+                    11092,  50000,      -- (Body) Ferine Gausape +2
+                    11112,  50000,      -- (Hands) Ferine Manoplas +2
+                    11132,  50000,      -- (Legs) Ferine Quijotes +2
+                    11152,  50000,      -- (Feet) Ferine Ocreae +2
+                    11617,  50000,      -- (Neck) Ferine Necklace
+                    11711,  50000,      -- (Earring) Ferine Earring
+                    11555,  50000,      -- (Back) Ferine Mantle
+                    10658,  50000,      -- (Head) Monster Helm +2
+                    10678,  50000,      -- (Body) Monster Jackcoat +2
+                    10698,  50000,      -- (Hands) Monster Gloves +2
+                    10718,  50000,      -- (Legs) Monster Trousers +2
+                    10738,  50000,      -- (Feet) Monster Gaiters +2
+                    -- 25465,   50000,      -- (Neck) Beastmaster Collar
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_BST)
+    elseif (job == xi.job.BRD) then
+        local stock_BRD = {}
+        player:PrintToPlayer(string.format("Andreine : Your audiences will expect only the finest from their Bard!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_BRD =
+                {
+                    16610,  5000,       -- (Sword) Wax Sword +1
+                    16491,  5000,       -- (Dagger) Bronze Knife +1
+                    16492,  5000,       -- (Dagger) Bronze Dagger +1
+                    17372,  5000,       -- (Wind Instrument) Flute +1
+                    17373,  5000,       -- (String Instrument) Maple Harp +1
+                    12744,  2000,       -- (Gloves) Cuffs +1
+                    12897,  2000,       -- (Legs) Slops +1
+                    12983,  2000,       -- (Feet) Ash Clogs +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13072,  2000,       -- (Neck) Bird Whistle
+                    13190,  2000,       -- (Waist) Heko Obi +1
+                    13605,  2000,       -- (Back) Cape +1
+                    14694,  2000,       -- (Earring) Energy Earring +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    13548,  50000,      -- (Ring) Astral Ring
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_BRD =
+                {
+                    16815,  15000,      -- (Sword) Mythril Degen +1
+                    17375,  10000,      -- (Wind Instrument) Traversiere +1
+                    17376,  10000,      -- (String Instrument) Rose Harp +1
+                    12538,  10000,      -- (Head) Red Cap +1
+                    12625,  10000,      -- (Body) Gambison +1
+                    12779,  10000,      -- (Hands) Bracers +1
+                    12903,  10000,      -- (Legs) Hose +1
+                    13034,  10000,      -- (Feet) Socks +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_BRD =
+                {
+                    16618,  25000,      -- (Sword) Mailbreaker +1
+                    17832,  15000,      -- (Wind Instrument) Shofar +1
+                    17833,  15000,      -- (String Instrument) Ebony Harp +1
+                    15234,  50000,      -- (Head) Choral Roundlet +1
+                    14482,  50000,      -- (Body) Choral Justaucorps +1
+                    14899,  50000,      -- (Hands) Choral Cuffs +1
+                    15570,  50000,      -- (Legs) Choral Cannions +1
+                    15361,  50000,      -- (Feet) Choral Slippers +1
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15525,  10000,      -- (Neck) Grandiose Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15887,  10000,      -- (Neck) Resolute Belt
+                    15490,  10000,      -- (Back) Miraculous Cape
+                    16009,  10000,      -- (Earring) Pennon Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_BRD =
+                {
+                    17719,  40000,      -- (Sword) Mensur Epee
+                    11073,  50000,      -- (Head) Aoidos' Calot +2
+                    11093,  50000,      -- (Body) Aoidos' Hongreline +2
+                    11113,  50000,      -- (Hands) Aoidos' Manchettes +2
+                    11133,  50000,      -- (Legs) Aoidos' Rhingrave +2
+                    11153,  50000,      -- (Feet) Aoidos' Cothurnes +2
+                    11618,  50000,      -- (Neck) Aoidos' Matinee
+                    11712,  50000,      -- (Earring) Aoidos' Earring
+                    11738,  50000,      -- (Waist) Aoidos' Belt
+                    10659,  50000,      -- (Head) Bard's Roundlet +2
+                    10679,  50000,      -- (Body) Bard's Justaucorps +2
+                    10699,  50000,      -- (Hands) Bard's Cuffs +2
+                    10719,  50000,      -- (Legs) Bard's Cannions +2
+                    10739,  50000,      -- (Feet) Bard's Slippers +2
+                    11608,  30000,      -- (Neck) Barcarolle Medal
+                    11745,  30000,      -- (Waist) Aristo Belt
+                    11563,  30000,      -- (Back) Mesmeric Cape
+                    11724,  30000,      -- (Earring) Reverie Earring +1
+                    14643,  30000,      -- (Ring) Apollo's Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_BRD =
+                {
+                    20743,  100000,     -- (Sword) Bihkah Sword +1
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11073,  50000,      -- (Head) Aoidos' Calot +2
+                    11093,  50000,      -- (Body) Aoidos' Hongreline +2
+                    11113,  50000,      -- (Hands) Aoidos' Manchettes +2
+                    11133,  50000,      -- (Legs) Aoidos' Rhingrave +2
+                    11153,  50000,      -- (Feet) Aoidos' Cothurnes +2
+                    11618,  50000,      -- (Neck) Aoidos' Matinee
+                    11712,  50000,      -- (Earring) Aoidos' Earring
+                    11738,  50000,      -- (Waist) Aoidos' Belt
+                    10659,  50000,      -- (Head) Bard's Roundlet +2
+                    10679,  50000,      -- (Body) Bard's Justaucorps +2
+                    10699,  50000,      -- (Hands) Bard's Cuffs +2
+                    10719,  50000,      -- (Legs) Bard's Cannions +2
+                    10739,  50000,      -- (Feet) Bard's Slippers +2
+                    -- 25471,   50000,      -- (Neck) Bard's Charm
+                    10826,  50000,      -- (Waist) Witful Belt
+                    11012,  50000,      -- (Back) Gwyddion's Cape
+                    11036,  50000,      -- (Earring) Enchanter's Earring
+                    11701,  50000,      -- (Earring) Skald Breloque
+                    -- 27576,   50000,      -- (Ring) Carbuncle Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_BRD)
+    elseif (job == xi.job.RNG) then
+        local stock_RNG = {}
+        player:PrintToPlayer(string.format("Andreine : I had no idea there were so many types of ranged weapons! How do you Rangers choose?"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_RNG =
+                {
+                    16610,  5000,       -- (Sword) Wax Sword +1
+                    16491,  5000,       -- (Dagger) Bronze Knife +1
+                    16492,  5000,       -- (Dagger) Bronze Dagger +1
+                    17175,  5000,       -- (Archery) Shortbow +1
+                    17177,  5000,       -- (Archery) Longbow +1
+                    17228,  5000,       -- (Marksmanship) Light Crossbow +1
+                    19225,  5000,       -- (Marksmanship) Musketoon +1
+                    4219,   200,        -- (Ammunition) Stone Arrow Quiver
+                    4227,   200,        -- (Ammunition) Bronze Bolt Quiver
+                    5359,   200,        -- (Ammunition) Bronze Bullet Pouch
+                    12744,  2000,       -- (Gloves) Cuffs +1
+                    12897,  2000,       -- (Legs) Slops +1
+                    12983,  2000,       -- (Feet) Ash Clogs +1
+                    13060,  2000,       -- (Neck) Feather Collar +1
+                    13117,  2000,       -- (Neck) Ranger's Necklace
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_RNG =
+                {
+                    19106,  10000,      -- (Dagger) Thug's Jambiya +1
+                    17180,  15000,      -- (Archery) Great Bow +1
+                    17229,  15000,      -- (Marksmanship) Zamburak +1
+                    17260,  15000,      -- (Marksmanship) Pirate's Gun +1
+                    4222,   2000,       -- (Ammunition) Horn Arrow Quiver
+                    4228,   2000,       -- (Ammunition) Mythril Bolt Quiver
+                    5363,   2000,       -- (Ammunition) Bullet Pouch
+                    15161,  10000,      -- (Head) Noct Beret
+                    14422,  10000,      -- (Body) Noct Doublet
+                    14854,  10000,      -- (Hands) Noct Gloves
+                    14323,  10000,      -- (Legs) Noct Brais
+                    15311,  10000,      -- (Feet) Noct Gaiters
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_RNG =
+                {
+                    17603,  15000,      -- (Dagger) Cermet Kukri +1
+                    17189,  25000,      -- (Archery) Rapid Bow +1
+                    17227,  25000,      -- (Marksmanship) Heavy Crossbow +1
+                    19227,  25000,      -- (Marksmanship) Blunderbuss +1
+                    4224,   5000,       -- (Ammunition) Demon Arrow Quiver
+                    4229,   5000,       -- (Ammunition) Darksteel Bolt Quiver
+                    5353,   5000,       -- (Ammunition) Iron Bullet Pouch
+                    15235,  50000,      -- (Head) Hunter's Beret +1
+                    14483,  50000,      -- (Body) Hunter's Jerkin +1
+                    14900,  50000,      -- (Hands) Hunter's Bracers +1
+                    15571,  50000,      -- (Legs) Hunter's Braccae +1
+                    15362,  50000,      -- (Feet) Hunter's Socks +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13369,  10000,      -- (Earring) Spike Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_RNG =
+                {
+                    16481,  35000,      -- (Dagger) Yataghan +1
+                    18701,  40000,      -- (Archery) Cerberus Bow +1
+                    19266,  40000,      -- (Marksmanship) Darkwing +1
+                    19268,  40000,      -- (Marksmanship) Ribauldequin +1
+                    5819,   7500,       -- (Ammunition) Antlion Arrow Quiver
+                    5821,   7500,       -- (Ammunition) Fusion Bolt Quiver
+                    5823,   7500,       -- (Ammunition) Oberon's Bullet Pouch
+                    11074,  50000,      -- (Head) Sylvan Gapette +2
+                    11094,  50000,      -- (Body) Sylvan Caban +2
+                    11114,  50000,      -- (Hands) Sylvan Glovelettes +2
+                    11134,  50000,      -- (Legs) Sylvan Bragues +2
+                    11154,  50000,      -- (Feet) Sylvan Bottillons +2
+                    11596,  50000,      -- (Neck) Sylvan Scarf
+                    11713,  50000,      -- (Earring) Sylvan Earring
+                    16205,  50000,      -- (Back) Sylvan Chlamys
+                    10660,  50000,      -- (Head) Scout's Beret +2
+                    10680,  50000,      -- (Body) Scout's Jerkin +2
+                    10700,  50000,      -- (Hands) Scout's Bracers +2
+                    10720,  50000,      -- (Legs) Scout's Braccae +2
+                    10740,  50000,      -- (Feet) Scout's Socks +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11681,  30000,      -- (Earring) Breeze Earring
+                    14636,  30000,      -- (Ring) Breeze Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_RNG =
+                {
+                    20642,  65000,      -- (Dagger) Tzustes Knife +1
+                    21244,  100000,     -- (Archery) Ahkormaar Bow +1
+                    21259,  100000,     -- (Marksmanship) Malayo Crossbow +1
+                    21293,  100000,     -- (Marksmanship) Bandeiras Gun +1
+                    6137,   11500,      -- (Ammunition) Chapuli Arrow Quiver
+                    6139,   11500,      -- (Ammunition) Midrium Bolt Quiver
+                    6142,   11500,      -- (Ammunition) Midrium Bullet Pouch
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11074,  50000,      -- (Head) Sylvan Gapette +2
+                    11094,  50000,      -- (Body) Sylvan Caban +2
+                    11114,  50000,      -- (Hands) Sylvan Glovelettes +2
+                    11134,  50000,      -- (Legs) Sylvan Bragues +2
+                    11154,  50000,      -- (Feet) Sylvan Bottillons +2
+                    11596,  50000,      -- (Neck) Sylvan Scarf
+                    11713,  50000,      -- (Earring) Sylvan Earring
+                    16205,  50000,      -- (Back) Sylvan Chlamys
+                    10660,  50000,      -- (Head) Scout's Beret +2
+                    10680,  50000,      -- (Body) Scout's Jerkin +2
+                    10700,  50000,      -- (Hands) Scout's Bracers +2
+                    10720,  50000,      -- (Legs) Scout's Braccae +2
+                    10740,  50000,      -- (Feet) Scout's Socks +2
+                    -- 25477,   50000,      -- (Neck) Scout's Gorget
+                    11735,  50000,      -- (Waist) Impulse Belt
+                    --26337,    50000,      -- (Waist) Kwahu Kachina Belt
+                    11006,  50000,      -- (Back) Thall Mantle
+                    11046,  50000,      -- (Earring) Ouesk Pearl
+                    28513,  50000,      -- (Earring) Phawaylla Earring
+                    11058,  50000,      -- (Ring) Hajduk Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_RNG)
+    elseif (job == xi.job.SAM) then
+        local stock_SAM = {}
+        player:PrintToPlayer(string.format("Andreine : Well met noble Samurai! There are demons which must taste the steel of your blade."),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_SAM =
+                {
+                    17809,  5000,       -- (Great Katana) Mumeito
+                    17177,  5000,       -- (Archery) Longbow +1
+                    4219,   200,        -- (Ammunition) Stone Arrow Quiver
+                    12774,  2000,       -- (Gloves) Tekko +1
+                    12899,  2000,       -- (Legs) Sitabaki +1
+                    13031,  2000,       -- (Feet) Kyahan +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_SAM =
+                {
+                    16988,  15000,      -- (Great Katana) Kotetsu
+                    17180,  15000,      -- (Archery) Great Bow +1
+                    4222,   2000,       -- (Ammunition) Horn Arrow Quiver
+                    12539,  10000,      -- (Head) Soil Hachimaki +1
+                    12671,  10000,      -- (Body) Soil Gi +1
+                    12781,  10000,      -- (Hands) Soil Tekko +1
+                    12905,  10000,      -- (Legs) Soil Sitabaki +1
+                    13035,  10000,      -- (Feet) Soil Kyahan +1
+                    13070,  5000,       -- (Neck) Wolf Gorget +1
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13519,  5000,       -- (Ring) Mythril Ring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_SAM =
+                {
+                    16990,  25000,      -- (Great Katana) Daihannya
+                    17189,  25000,      -- (Archery) Rapid Bow +1
+                    4224,   5000,       -- (Ammunition) Demon Arrow Quiver
+                    15236,  50000,      -- (Head) Myochin Kabuto +1
+                    14484,  50000,      -- (Body) Myochin Domaru +1
+                    14901,  50000,      -- (Hands) Myochin Kote +1
+                    15572,  50000,      -- (Legs) Myochin Haidate +1
+                    15363,  50000,      -- (Feet) Myochin Sune-Ate +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13369,  10000,      -- (Earring) Spike Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_SAM =
+                {
+                    16977,  40000,      -- (Great Katana) Yukitsugu +1
+                    18701,  40000,      -- (Archery) Cerberus Bow +1
+                    5819,   7500,       -- (Ammunition) Antlion Arrow Quiver
+                    11075,  50000,      -- (Head) Unkai Kabuto +2
+                    11095,  50000,      -- (Body) Unkai Domaru +2
+                    11115,  50000,      -- (Hands) Unkai Kote +2
+                    11135,  50000,      -- (Legs) Unkai Haidate +2
+                    11155,  50000,      -- (Feet) Unkai Sune-Ate +2
+                    11597,  50000,      -- (Neck) Unkai Nodowa
+                    11714,  50000,      -- (Earring) Unkai Mimikazari
+                    16206,  50000,      -- (Back) Unkai Sugemino
+                    10661,  50000,      -- (Head) Saotome Kabuto +2
+                    10681,  50000,      -- (Body) Saotome Domaru +2
+                    10701,  50000,      -- (Hands) Saotome Kote +2
+                    10721,  50000,      -- (Legs) Saotome Haidate +2
+                    10741,  50000,      -- (Feet) Saotome Sune-Ate +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11678,  30000,      -- (Earring) Flame Earring
+                    14630,  30000,      -- (Ring) Flame Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_SAM =
+                {
+                    21057,  100000,     -- (Great Katana) Tomonari +1
+                    19787,  100000,     -- (Archery) Nurigomeyumi +1
+                    6137,   11500,      -- (Ammunition) Chapuli Arrow Quiver
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11075,  50000,      -- (Head) Unkai Kabuto +2
+                    11095,  50000,      -- (Body) Unkai Domaru +2
+                    11115,  50000,      -- (Hands) Unkai Kote +2
+                    11135,  50000,      -- (Legs) Unkai Haidate +2
+                    11155,  50000,      -- (Feet) Unkai Sune-Ate +2
+                    11597,  50000,      -- (Neck) Unkai Nodowa
+                    11714,  50000,      -- (Earring) Unkai Mimikazari
+                    16206,  50000,      -- (Back) Unkai Sugemino
+                    10661,  50000,      -- (Head) Saotome Kabuto +2
+                    10681,  50000,      -- (Body) Saotome Domaru +2
+                    10701,  50000,      -- (Hands) Saotome Kote +2
+                    10721,  50000,      -- (Legs) Saotome Haidate +2
+                    10741,  50000,      -- (Feet) Saotome Sune-Ate +2
+                    -- 25483,   50000,      -- (Neck) Samurai's Nodowa
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_SAM)
+    elseif (job == xi.job.NIN) then
+        local stock_NIN = {}
+        player:PrintToPlayer(string.format("Andreine : Oh! You Ninjas always startle me when you appear out of nowhere like that!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_NIN =
+                {
+                    16914,  5000,       -- (Katana) Kunai +1
+                    17307,  2,          -- (Throwing) Dart
+                    6299,   500,        -- (Throwing) Shuriken Pouch
+                    12774,  2000,       -- (Gloves) Tekko +1
+                    12899,  2000,       -- (Legs) Sitabaki +1
+                    13031,  2000,       -- (Feet) Kyahan +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_NIN =
+                {
+                    16921,  10000,      -- (Katana) Kodachi +1
+                    6297,   2000,       -- (Throwing) Juji Shuriken Pouch
+                    12539,  10000,      -- (Head) Soil Hachimaki +1
+                    12671,  10000,      -- (Body) Soil Gi +1
+                    12781,  10000,      -- (Hands) Soil Tekko +1
+                    12905,  10000,      -- (Legs) Soil Sitabaki +1
+                    13035,  10000,      -- (Feet) Soil Kyahan +1
+                    13070,  5000,       -- (Neck) Wolf Gorget +1
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13519,  5000,       -- (Ring) Mythril Ring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_NIN =
+                {
+                    16923,  15000,      -- (Katana) Kabutowari +1
+                    6302,   5000,       -- (Throwing) Fuma Shuriken Pouch
+                    15237,  50000,      -- (Head) Ninja Hatsuburi +1
+                    14485,  50000,      -- (Body) Ninja Chainmail +1
+                    14902,  50000,      -- (Hands) Ninja Tekko +1
+                    15573,  50000,      -- (Legs) Ninja Hakama +1
+                    15364,  50000,      -- (Feet) Ninja Kyahan +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13369,  10000,      -- (Earring) Spike Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_NIN =
+                {
+                    19286,  35000,      -- (Katana) Kakko +1
+                    6300,   7500,       -- (Throwing) Koga Shuriken Pouch
+                    11076,  50000,      -- (Head) Iga Zukin +2
+                    11096,  50000,      -- (Body) Iga Ningi +2
+                    11116,  50000,      -- (Hands) Iga Tekko +2
+                    11136,  50000,      -- (Legs) Iga Hakama +2
+                    11156,  50000,      -- (Feet) Iga Kyahan +2
+                    11598,  50000,      -- (Neck) Iga Erimaki
+                    11715,  50000,      -- (Earring) Iga Mimikazari
+                    16207,  50000,      -- (Back) Iga Dochugappa
+                    10662,  50000,      -- (Head) Koga Hatsuburi +2
+                    10682,  50000,      -- (Body) Koga Chainmail +2
+                    10702,  50000,      -- (Hands) Koga Tekko +2
+                    10722,  50000,      -- (Legs) Koga Hakama +2
+                    10742,  50000,      -- (Feet) Koga Kyahan +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11678,  30000,      -- (Earring) Flame Earring
+                    14630,  30000,      -- (Ring) Flame Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_NIN =
+                {
+                    21010,  65000,      -- (Katana) Nakajimarai +1
+                    6304,   12000,      -- (Throwing) Roppo Shuriken Pouch
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11076,  50000,      -- (Head) Iga Zukin +2
+                    11096,  50000,      -- (Body) Iga Ningi +2
+                    11116,  50000,      -- (Hands) Iga Tekko +2
+                    11136,  50000,      -- (Legs) Iga Hakama +2
+                    11156,  50000,      -- (Feet) Iga Kyahan +2
+                    11598,  50000,      -- (Neck) Iga Erimaki
+                    11715,  50000,      -- (Earring) Iga Mimikazari
+                    16207,  50000,      -- (Back) Iga Dochugappa
+                    10662,  50000,      -- (Head) Koga Hatsuburi +2
+                    10682,  50000,      -- (Body) Koga Chainmail +2
+                    10702,  50000,      -- (Hands) Koga Tekko +2
+                    10722,  50000,      -- (Legs) Koga Hakama +2
+                    10742,  50000,      -- (Feet) Koga Kyahan +2
+                    -- 25489,   50000,      -- (Neck) Ninja Nodowa
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    28492,  50000,      -- (Earring) Hibernation Earring
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_NIN)
+    elseif (job == xi.job.DRG) then
+        local stock_DRG = {}
+        player:PrintToPlayer(string.format("Andreine : It's so good to see a Dragoon again! Give your wyvern a special treat from me!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_DRG =
+                {
+                    16862,  5000,       -- (Polearm) Harpoon +1
+                    12695,  2000,       -- (Gloves) Bronze Mittens +1
+                    12823,  2000,       -- (Legs) Bronze Subligar +1
+                    12951,  2000,       -- (Feet) Bronze Leggings +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_DRG =
+                {
+                    16876,  15000,      -- (Polearm) Lance +1
+                    13824,  10000,      -- (Head) Strong Bandana
+                    13707,  10000,      -- (Body) Strong Vest
+                    12786,  10000,      -- (Hands) Strong Gloves
+                    12910,  10000,      -- (Legs) Strong Trousers
+                    13039,  10000,      -- (Feet) Strong Boots
+                    13070,  5000,       -- (Neck) Wolf Gorget +1
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13519,  5000,       -- (Ring) Mythril Ring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_DRG =
+                {
+                    18119,  25000,      -- (Polearm) Dark Mezraq +1
+                    18259,  200,        -- (Ammunition) Angon
+                    15238,  50000,      -- (Head) Drachen Armet +1
+                    14486,  50000,      -- (Body) Drachen Mail +1
+                    14903,  50000,      -- (Hands) Drachen Finger Gauntlets +1
+                    15574,  50000,      -- (Legs) Drachen Brais +1
+                    15365,  50000,      -- (Feet) Drachen Greaves +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13403,  10000,      -- (Earring) Assault Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_DRG =
+                {
+                    18111,  40000,      -- (Polearm) Mezraq +1
+                    18259,  200,        -- (Ammunition) Angon
+                    11077,  50000,      -- (Head) Lancer's Mezail +2
+                    11097,  50000,      -- (Body) Lancer's Plackart +2
+                    11117,  50000,      -- (Hands) Lancer's Vambraces +2
+                    11137,  50000,      -- (Legs) Lancer's Cuissots +2
+                    11157,  50000,      -- (Feet) Lancer's Schynbalds +2
+                    11599,  50000,      -- (Neck) Lancer's Torque
+                    11716,  50000,      -- (Earring) Lancer's Earring
+                    16208,  50000,      -- (Back) Lancer's Pelerine
+                    10663,  50000,      -- (Head) Wyrm Armet +2
+                    10683,  50000,      -- (Body) Wyrm Mail +2
+                    10703,  50000,      -- (Hands) Wyrm Finger Gauntlets +2
+                    10723,  50000,      -- (Legs) Wyrm Brais +2
+                    10743,  50000,      -- (Feet) Wyrm Greaves +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11678,  30000,      -- (Earring) Flame Earring
+                    14630,  30000,      -- (Ring) Flame Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_DRG =
+                {
+                    19799,  300000,     -- (Polearm) Herja's Fork
+                    20968,  100000,     -- (Polearm) Chanar Xyston +1
+                    18259,  200,        -- (Ammunition) Angon
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11077,  50000,      -- (Head) Lancer's Mezail +2
+                    11097,  50000,      -- (Body) Lancer's Plackart +2
+                    11117,  50000,      -- (Hands) Lancer's Vambraces +2
+                    11137,  50000,      -- (Legs) Lancer's Cuissots +2
+                    11157,  50000,      -- (Feet) Lancer's Schynbalds +2
+                    11599,  50000,      -- (Neck) Lancer's Torque
+                    11716,  50000,      -- (Earring) Lancer's Earring
+                    16208,  50000,      -- (Back) Lancer's Pelerine
+                    10663,  50000,      -- (Head) Wyrm Armet +2
+                    10683,  50000,      -- (Body) Wyrm Mail +2
+                    10703,  50000,      -- (Hands) Wyrm Finger Gauntlets +2
+                    10723,  50000,      -- (Legs) Wyrm Brais +2
+                    10743,  50000,      -- (Feet) Wyrm Greaves +2
+                    -- 25495,   50000,      -- (Neck) Dragoon's Collar
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_DRG)
+    elseif (job == xi.job.SMN) then
+        local stock_SMN = {}
+        player:PrintToPlayer(string.format("Andreine : Greetings noble Summoner! Are all of the avatars getting along today?"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_SMN =
+                {
+                    17123,  5000,       -- (Staff) Ash Staff +1
+                    17122,  5000,       -- (Staff) Ash Pole +1
+                    12744,  2000,       -- (Gloves) Cuffs +1
+                    12897,  2000,       -- (Legs) Slops +1
+                    12983,  2000,       -- (Feet) Ash Clogs +1
+                    13093,  2000,       -- (Neck) Justice Badge
+                    13190,  2000,       -- (Waist) Heko Obi +1
+                    13605,  2000,       -- (Back) Cape +1
+                    14694,  2000,       -- (Earring) Energy Earring +1
+                    13440,  2000,       -- (Ring) Ascetic's Ring
+                    13548,  50000,      -- (Ring) Astral Ring
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_SMN =
+                {
+                    17534,  15000,      -- (Staff) Whale Staff +1
+                    17119,  15000,      -- (Staff) Elm Pole +1
+                    12538,  10000,      -- (Head) Red Cap +1
+                    12625,  10000,      -- (Body) Gambison +1
+                    12779,  10000,      -- (Hands) Bracers +1
+                    12903,  10000,      -- (Legs) Hose +1
+                    13034,  10000,      -- (Feet) Socks +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13233,  5000,       -- (Waist) Gold Obi +1
+                    13618,  5000,       -- (Back) White Cape +1
+                    14702,  5000,       -- (Earring) Aura Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_SMN =
+                {
+                    17520,  25000,      -- (Staff) Heavy Staff +1
+                    17521,  25000,      -- (Staff) Mahogany Pole +1
+                    15239,  50000,      -- (Head) Evoker's Horn +1
+                    14487,  50000,      -- (Body) Evoker's Doublet +1
+                    14904,  50000,      -- (Hands) Evoker's Bracers +1
+                    15575,  50000,      -- (Legs) Evoker's Spats +1
+                    15366,  50000,      -- (Feet) Evoker's Pigaches +1
+                    15887,  10000,      -- (Neck) Resolute Belt
+                    15885,  10000,      -- (Neck) Spectral Belt
+                    15490,  10000,      -- (Back) Miraculous Cape
+                    15971,  10000,      -- (Earring) Antivenom Earring
+                    15972,  10000,      -- (Earring) Insomnia Earring
+                    15776,  10000,      -- (Ring) Ebullient Ring
+                    15777,  10000,      -- (Ring) Hale Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_SMN =
+                {
+                    17578,  40000,      -- (Staff) Zen Pole
+                    17277,  20000,      -- (Ammunition) Hedgehog Bomb
+                    11078,  50000,      -- (Head) Caller's Horn +2
+                    11098,  50000,      -- (Body) Caller's Doublet +2
+                    11118,  50000,      -- (Hands) Caller's Bracers +2
+                    11138,  50000,      -- (Legs) Caller's Spats +2
+                    11158,  50000,      -- (Feet) Caller's Pigaches +2
+                    11619,  50000,      -- (Neck) Caller's Pendant
+                    11717,  50000,      -- (Earring) Caller's Earring
+                    11739,  50000,      -- (Back) Caller's Sash
+                    10664,  50000,      -- (Head) Summoner's Horn +2
+                    10684,  50000,      -- (Body) Summoner's Doublet +2
+                    10704,  50000,      -- (Hands) Summoner's Bracers +2
+                    10724,  50000,      -- (Legs) Summoner's Spats +2
+                    10744,  50000,      -- (Feet) Summoner's Pigaches +2
+                    11579,  30000,      -- (Neck) Fylgja Torque
+                    15949,  30000,      -- (Waist) Pythia Sash +1
+                    11564,  30000,      -- (Back) Tiresias' Cape
+                    11685,  30000,      -- (Earring) Darkness Earring
+                    14644,  30000,      -- (Ring) Dark Ring
+                    14625,  100000,     -- (Ring) Evoker's Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_SMN =
+                {
+                    21208,  100000,     -- (Staff) Lehbrailg
+                    19780,  30000,      -- (Ammunition) Mana Ampulla
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11078,  50000,      -- (Head) Caller's Horn +2
+                    11098,  50000,      -- (Body) Caller's Doublet +2
+                    11118,  50000,      -- (Hands) Caller's Bracers +2
+                    11138,  50000,      -- (Legs) Caller's Spats +2
+                    11158,  50000,      -- (Feet) Caller's Pigaches +2
+                    11619,  50000,      -- (Neck) Caller's Pendant
+                    11717,  50000,      -- (Earring) Caller's Earring
+                    11739,  50000,      -- (Back) Caller's Sash
+                    10664,  50000,      -- (Head) Summoner's Horn +2
+                    10684,  50000,      -- (Body) Summoner's Doublet +2
+                    10704,  50000,      -- (Hands) Summoner's Bracers +2
+                    10724,  50000,      -- (Legs) Summoner's Spats +2
+                    10744,  50000,      -- (Feet) Summoner's Pigaches +2
+                    -- 25501,   50000,      -- (Neck) Summoner's Collar
+                    10842,  50000,      -- (Waist) Bougonia Rope
+                    27607,  50000,      -- (Back) Thaumaturge's Cape
+                    11021,  30000,      -- (Earring) Darkness Pearl
+                    -- 27578,   30000,      -- (Ring) Fenrir Ring
+                    14625,  100000,     -- (Ring) Evoker's Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_SMN)
+    elseif (job == xi.job.BLU) then
+        local stock_BLU = {}
+        player:PrintToPlayer(string.format("Andreine : You may know the secrets of monster techniques Blue Mage but I have the gear you'll need!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_BLU =
+                {
+                    16610,  5000,       -- (Sword) Wax Sword +1
+                    12695,  2000,       -- (Gloves) Bronze Mittens +1
+                    12823,  2000,       -- (Legs) Bronze Subligar +1
+                    12951,  2000,       -- (Feet) Bronze Leggings +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13190,  2000,       -- (Waist) Heko Obi +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    14694,  2000,       -- (Earring) Energy Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_BLU =
+                {
+                    17740,  15000,      -- (Sword) Steel Kilij +1
+                    15173,  10000,      -- (Head) Kosshin
+                    13730,  10000,      -- (Body) Frost Robe
+                    12750,  10000,      -- (Hands) New Moon Armlets
+                    12904,  10000,      -- (Legs) Linen Slacks +1
+                    13040,  10000,      -- (Feet) Shoes +1
+                    13070,  5000,       -- (Neck) Wolf Gorget +1
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13506,  5000,       -- (Ring) Bomb Ring
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_BLU =
+                {
+                    17639,  25000,      -- (Sword) Cutlass +1
+                    11464,  50000,      -- (Head) Magus Keffiyeh +1
+                    11291,  50000,      -- (Body) Magus Jubbah +1
+                    15024,  50000,      -- (Hands) Magus Bazubands +1
+                    16345,  50000,      -- (Legs) Magus Shalwar +1
+                    11381,  50000,      -- (Feet) Magus Charuqs +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15887,  10000,      -- (Waist) Resolute Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13369,  10000,      -- (Earring) Spike Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_BLU =
+                {
+                    17664,  40000,      -- (Sword) Firmament +1
+                    11079,  50000,      -- (Head) Mavi Kavuk +2
+                    11099,  50000,      -- (Body) Mavi Mintan +2
+                    11119,  50000,      -- (Hands) Mavi Bazubands +2
+                    11139,  50000,      -- (Legs) Mavi Tayt +2
+                    11159,  50000,      -- (Feet) Mavi Basmak +2
+                    19255,  50000,      -- (Ammunition) Mavi Tathlum
+                    11600,  50000,      -- (Neck) Mavi Scarf
+                    11718,  50000,      -- (Earring) Mavi Earring
+                    10665,  50000,      -- (Head) Mirage Keffiyeh +2
+                    10685,  50000,      -- (Body) Mirage Jubbah +2
+                    10705,  50000,      -- (Hands) Mirage Bazubands +2
+                    10725,  50000,      -- (Legs) Mirage Shalwar +2
+                    10745,  50000,      -- (Feet) Mirage Charuqs +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11678,  30000,      -- (Earring) Flame Earring
+                    14630,  30000,      -- (Ring) Flame Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_BLU =
+                {
+                    18916,  300000,     -- (Sword) Heimdall's Doom
+                    20743,  100000,     -- (Sword) Bihkah Sword +1
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11079,  50000,      -- (Head) Mavi Kavuk +2
+                    11099,  50000,      -- (Body) Mavi Mintan +2
+                    11119,  50000,      -- (Hands) Mavi Bazubands +2
+                    11139,  50000,      -- (Legs) Mavi Tayt +2
+                    11159,  50000,      -- (Feet) Mavi Basmak +2
+                    19255,  50000,      -- (Ammunition) Mavi Tathlum
+                    11600,  50000,      -- (Neck) Mavi Scarf
+                    11718,  50000,      -- (Earring) Mavi Earring
+                    10665,  50000,      -- (Head) Mirage Keffiyeh +2
+                    10685,  50000,      -- (Body) Mirage Jubbah +2
+                    10705,  50000,      -- (Hands) Mirage Bazubands +2
+                    10725,  50000,      -- (Legs) Mirage Shalwar +2
+                    10745,  50000,      -- (Feet) Mirage Charuqs +2
+                    -- 25507,   50000,      -- (Neck) Mirage Stole
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_BLU)
+    elseif (job == xi.job.COR) then
+        local stock_COR = {}
+        player:PrintToPlayer(string.format("Andreine : Ready to roll the dice Corsair? I wish you the best of luck out there!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_COR =
+                {
+                    16624,  5000,       -- (Sword) Xiphos +1
+                    16491,  5000,       -- (Dagger) Bronze Knife +1
+                    19225,  5000,       -- (Marksmanship) Musketoon +1
+                    5359,   200,        -- (Ammunition) Bronze Bullet Pouch
+                    12695,  2000,       -- (Gloves) Bronze Mittens +1
+                    12823,  2000,       -- (Legs) Bronze Subligar +1
+                    12951,  2000,       -- (Feet) Bronze Leggings +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_COR =
+                {
+                    19106,  10000,      -- (Dagger) Thug's Jambiya +1
+                    17260,  15000,      -- (Marksmanship) Pirate's Gun +1
+                    5363,   2000,       -- (Ammunition) Bullet Pouch
+                    15161,  10000,      -- (Head) Noct Beret
+                    14422,  10000,      -- (Body) Noct Doublet
+                    14854,  10000,      -- (Hands) Noct Gloves
+                    14323,  10000,      -- (Legs) Noct Brais
+                    15311,  10000,      -- (Feet) Noct Gaiters
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_COR =
+                {
+                    17603,  15000,      -- (Dagger) Cermet Kukri +1
+                    19227,  25000,      -- (Marksmanship) Blunderbuss +1
+                    5353,   5000,       -- (Ammunition) Iron Bullet Pouch
+                    11467,  50000,      -- (Head) Corsair's Tricorne +1
+                    11294,  50000,      -- (Body) Corsair's Frac +1
+                    15027,  50000,      -- (Hands) Corsair's Gants +1
+                    16348,  50000,      -- (Legs) Corsair's Culottes +1
+                    11384,  50000,      -- (Feet) Corsair's Bottes +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13369,  10000,      -- (Earring) Spike Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_COR =
+                {
+                    16481,  35000,      -- (Dagger) Yataghan +1
+                    19268,  40000,      -- (Marksmanship) Ribauldequin +1
+                    5823,   7500,       -- (Ammunition) Oberon's Bullet Pouch
+                    11080,  50000,      -- (Head) Navarch's Tricorne +2
+                    11100,  50000,      -- (Body) Navarch's Frac +2
+                    11120,  50000,      -- (Hands) Navarch's Gants +2
+                    11140,  50000,      -- (Legs) Navarch's Culottes +2
+                    11160,  50000,      -- (Feet) Navarch's Bottes +2
+                    11601,  50000,      -- (Neck) Navarch's Choker
+                    11719,  50000,      -- (Earring) Navarch's Earring
+                    16209,  50000,      -- (Back) Navarch's Mantle
+                    10666,  50000,      -- (Head) Commodore Tricorne +2
+                    10686,  50000,      -- (Body) Commodore Frac +2
+                    10706,  50000,      -- (Hands) Commodore Gants +2
+                    10726,  50000,      -- (Legs) Commodore Trews +2
+                    10746,  50000,      -- (Feet) Commodore Bottes +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11681,  30000,      -- (Earring) Breeze Earring
+                    14636,  30000,      -- (Ring) Breeze Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_COR =
+                {
+                    20642,  65000,      -- (Dagger) Tzustes Knife +1
+                    21293,  100000,     -- (Marksmanship) Bandeiras Gun +1
+                    6142,   11500,      -- (Ammunition) Midrium Bullet Pouch
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11080,  50000,      -- (Head) Navarch's Tricorne +2
+                    11100,  50000,      -- (Body) Navarch's Frac +2
+                    11120,  50000,      -- (Hands) Navarch's Gants +2
+                    11140,  50000,      -- (Legs) Navarch's Culottes +2
+                    11160,  50000,      -- (Feet) Navarch's Bottes +2
+                    11601,  50000,      -- (Neck) Navarch's Choker
+                    11719,  50000,      -- (Earring) Navarch's Earring
+                    16209,  50000,      -- (Back) Navarch's Mantle
+                    10666,  50000,      -- (Head) Commodore Tricorne +2
+                    10686,  50000,      -- (Body) Commodore Frac +2
+                    10706,  50000,      -- (Hands) Commodore Gants +2
+                    10726,  50000,      -- (Legs) Commodore Trews +2
+                    10746,  50000,      -- (Feet) Commodore Bottes +2
+                    -- 25513,   50000,      -- (Neck) Commodore Charm
+                    26337,  50000,      -- (Waist) Kwahu Kachina Belt
+                    11006,  50000,      -- (Back) Thall Mantle
+                    11046,  50000,      -- (Earring) Ouesk Pearl
+                    28513,  50000,      -- (Earring) Phawaylla Earring
+                    -- 27572,   50000,      -- (Ring) Garuda Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_COR)
+    elseif (job == xi.job.PUP) then
+        local stock_PUP = {}
+        player:PrintToPlayer(string.format("Andreine : Oh, how wonderful to see a Puppetmaster! Such finesse in controlling your puppet!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_PUP =
+                {
+                    17476,  5000,       -- (Hand-to-Hand) Cat Baghnakhs +1
+                    17859,  1000,       -- (Ranged) Animator
+                    12744,  2000,       -- (Gloves) Cuffs +1
+                    12897,  2000,       -- (Legs) Slops +1
+                    12983,  2000,       -- (Feet) Ash Clogs +1
+                    16282,  2000,       -- (Neck) Buffoon's Collar +1
+                    13226,  2000,       -- (Waist) Blood Stone +1
+                    13605,  2000,       -- (Back) Cape +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_PUP =
+                {
+                    16445,  15000,      -- (Hand-to-Hand) Claws +1
+                    17858,  5000,       -- (Ranged) Turbo Animator
+                    12538,  10000,      -- (Head) Red Cap +1
+                    12625,  10000,      -- (Body) Gambison +1
+                    12779,  10000,      -- (Hands) Bracers +1
+                    12903,  10000,      -- (Legs) Hose +1
+                    13034,  10000,      -- (Feet) Socks +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13233,  5000,       -- (Waist) Gold Obi +1
+                    13643,  5000,       -- (Back) Sarcenet Cape +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13519,  5000,       -- (Ring) Mythril Ring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_PUP =
+                {
+                    18751,  25000,      -- (Hand-to-Hand) Black Adargas +1
+                    17857,  15000,      -- (Ranged) Animator +1
+                    11470,  50000,      -- (Head) Puppetry Taj +1
+                    11297,  50000,      -- (Body) Puppetry Tobe +1
+                    15030,  50000,      -- (Hands) Puppetry Dastanas +1
+                    16351,  50000,      -- (Legs) Puppetry Churidars +1
+                    11387,  50000,      -- (Feet) Puppetry Babouches +1
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15492,  10000,      -- (Back) Intensifying Cape
+                    13369,  10000,      -- (Earring) Spike Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_PUP =
+                {
+                    18775,  40000,      -- (Hand-to-Hand) Savate Fists +1
+                    17923,  25000,      -- (Ranged) Deluxe Animator
+                    19249,  20000,      -- (Ammunition) Thew Bomblet
+                    11081,  50000,      -- (Head) Cirque Capello +2
+                    11101,  50000,      -- (Body) Cirque Farsetto +2
+                    11121,  50000,      -- (Hands) Cirque Guanti +2
+                    11141,  50000,      -- (Legs) Cirque Pantaloni +2
+                    11161,  50000,      -- (Feet) Cirque Scarpe +2
+                    11602,  50000,      -- (Neck) Cirque Necklace
+                    11720,  50000,      -- (Earring) Cirque Earring
+                    11751,  50000,      -- (Waist) Cirque Sash
+                    10667,  50000,      -- (Head) Pantin Taj +2
+                    10687,  50000,      -- (Body) Pantin Tobe +2
+                    10707,  50000,      -- (Hands) Pantin Dastanas +2
+                    10727,  50000,      -- (Legs) Pantin Churidars +2
+                    10747,  50000,      -- (Feet) Pantin Babouches +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11678,  30000,      -- (Earring) Flame Earring
+                    14630,  30000,      -- (Ring) Flame Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_PUP =
+                {
+                    20552,  100000,     -- (Hand-to-Hand) Akua Sainti +1
+                    17923,  25000,      -- (Ranged) Deluxe Animator
+                    19249,  20000,      -- (Ammunition) Thew Bomblet
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11081,  50000,      -- (Head) Cirque Capello +2
+                    11101,  50000,      -- (Body) Cirque Farsetto +2
+                    11121,  50000,      -- (Hands) Cirque Guanti +2
+                    11141,  50000,      -- (Legs) Cirque Pantaloni +2
+                    11161,  50000,      -- (Feet) Cirque Scarpe +2
+                    11602,  50000,      -- (Neck) Cirque Necklace
+                    11720,  50000,      -- (Earring) Cirque Earring
+                    11751,  50000,      -- (Waist) Cirque Sash
+                    10667,  50000,      -- (Head) Pantin Taj +2
+                    10687,  50000,      -- (Body) Pantin Tobe +2
+                    10707,  50000,      -- (Hands) Pantin Dastanas +2
+                    10727,  50000,      -- (Legs) Pantin Churidars +2
+                    10747,  50000,      -- (Feet) Pantin Babouches +2
+                    -- 25519,   50000,      -- (Neck) Puppetmaster's Collar
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10987,  50000,      -- (Back) Meanagh Cape
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_PUP)
+    elseif (job == xi.job.DNC) then
+        local stock_DNC = {}
+        player:PrintToPlayer(string.format("Andreine : The graceful movements of you Dancers are always so hypnotizing!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_DNC =
+                {
+                    16690,  5000,       -- (Hand-to-Hand) Cesti +1
+                    16491,  5000,       -- (Dagger) Bronze Knife +1
+                    12695,  2000,       -- (Gloves) Bronze Mittens +1
+                    12823,  2000,       -- (Legs) Bronze Subligar +1
+                    12951,  2000,       -- (Feet) Bronze Leggings +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+            xi.shop.general(player, stock_DNC)
+        elseif (level <= 60) then
+            stock_DNC =
+                {
+                    19106,  10000,      -- (Dagger) Thug's Jambiya +1
+                    12538,  10000,      -- (Head) Red Cap +1
+                    12625,  10000,      -- (Body) Gambison +1
+                    12779,  10000,      -- (Hands) Bracers +1
+                    12903,  10000,      -- (Legs) Hose +1
+                    13034,  10000,      -- (Feet) Socks +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_DNC =
+                {
+                    17603,  15000,      -- (Dagger) Cermet Kukri +1
+                    11476,  50000,      -- (Head) Dancer's Tiara +1 (Female)
+                    11303,  50000,      -- (Body) Dancer's Casaque +1 (Female)
+                    15036,  50000,      -- (Hands) Dancer's Bangles +1 (Female)
+                    16358,  50000,      -- (Legs) Dancer's Tights +1 (Female)
+                    11394,  50000,      -- (Feet) Dancer's Toe Shoes +1 (Female)
+                    11475,  50000,      -- (Head) Dancer's Tiara +1 (Male)
+                    11302,  50000,      -- (Body) Dancer's Casaque +1 (Male)
+                    15035,  50000,      -- (Hands) Dancer's Bangles +1 (Male)
+                    16357,  50000,      -- (Legs) Dancer's Tights +1 (Male)
+                    11393,  50000,      -- (Feet) Dancer's Toe Shoes +1 (Male)
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13369,  10000,      -- (Earring) Spike Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_DNC =
+                {
+                    16481,  35000,      -- (Dagger) Yataghan +1
+                    11082,  50000,      -- (Head) Charis Tiara +2
+                    11102,  50000,      -- (Body) Charis Casaque +2
+                    11122,  50000,      -- (Hands) Charis Bangles +2
+                    11142,  50000,      -- (Legs) Charis Tights +2
+                    11162,  50000,      -- (Feet) Charis Toe Shoes +2
+                    19256,  50000,      -- (Ammunition) Charis Feather
+                    11603,  50000,      -- (Neck) Charis Necklace
+                    11721,  50000,      -- (Earring) Charis Earring
+                    10668,  50000,      -- (Head) Etoile Tiara +2
+                    10688,  50000,      -- (Body) Etoile Casaque +2
+                    10708,  50000,      -- (Hands) Etoile Bangles +2
+                    10728,  50000,      -- (Legs) Etoile Tights +2
+                    10748,  50000,      -- (Feet) Etoile Toe Shoes +2
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11679,  30000,      -- (Earring) Thunder Earring
+                    14638,  30000,      -- (Ring) Thunder Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_DNC =
+                {
+                    20642,  65000,      -- (Dagger) Tzustes Knife +1
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11082,  50000,      -- (Head) Charis Tiara +2
+                    11102,  50000,      -- (Body) Charis Casaque +2
+                    11122,  50000,      -- (Hands) Charis Bangles +2
+                    11142,  50000,      -- (Legs) Charis Tights +2
+                    11162,  50000,      -- (Feet) Charis Toe Shoes +2
+                    19256,  50000,      -- (Ammunition) Charis Feather
+                    11603,  50000,      -- (Neck) Charis Necklace
+                    11721,  50000,      -- (Earring) Charis Earring
+                    10668,  50000,      -- (Head) Etoile Tiara +2
+                    10688,  50000,      -- (Body) Etoile Casaque +2
+                    10708,  50000,      -- (Hands) Etoile Bangles +2
+                    10728,  50000,      -- (Legs) Etoile Tights +2
+                    10748,  50000,      -- (Feet) Etoile Toe Shoes +2
+                    -- 25525,   50000,      -- (Neck) Etoile Gorget
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_DNC)
+    elseif (job == xi.job.SCH) then
+        local stock_SCH = {}
+        player:PrintToPlayer(string.format("Andreine : You've got the book knowledge Scholar, now you just need the gear!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_SCH =
+                {
+                    17087,  5000,       -- (Club) Maple Wand +1
+                    17137,  5000,       -- (Club) Ash Club +1
+                    17123,  5000,       -- (Staff) Ash Staff +1
+                    17122,  5000,       -- (Staff) Ash Pole +1
+                    12744,  2000,       -- (Gloves) Cuffs +1
+                    12897,  2000,       -- (Legs) Slops +1
+                    12983,  2000,       -- (Feet) Ash Clogs +1
+                    13093,  2000,       -- (Neck) Justice Badge
+                    13190,  2000,       -- (Waist) Heko Obi +1
+                    13605,  2000,       -- (Back) Cape +1
+                    14694,  2000,       -- (Earring) Energy Earring +1
+                    13440,  2000,       -- (Ring) Ascetic's Ring
+                    13475,  2000,       -- (Ring) Hermit's Ring
+                    13548,  50000,      -- (Ring) Astral Ring
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+            xi.shop.general(player, stock_SCH)
+        elseif (level <= 60) then
+            stock_SCH =
+                {
+                    17141,  15000,      -- (Club) Solid Wand
+                    17409,  15000,      -- (Club) Mythril Rod +1
+                    17534,  15000,      -- (Staff) Whale Staff +1
+                    17119,  15000,      -- (Staff) Elm Pole +1
+                    15173,  10000,      -- (Head) Kosshin
+                    13730,  10000,      -- (Body) Frost Robe
+                    12750,  10000,      -- (Hands) New Moon Armlets
+                    12904,  10000,      -- (Legs) Linen Slacks +1
+                    13040,  10000,      -- (Feet) Shoes +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13233,  5000,       -- (Waist) Gold Obi +1
+                    13610,  5000,       -- (Back) Black Cape +1
+                    14702,  5000,       -- (Earring) Aura Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_SCH =
+                {
+                    17427,  25000,      -- (Club) Ebony Wand +1
+                    17435,  25000,      -- (Club) Darksteel Rod +1
+                    17520,  25000,      -- (Staff) Heavy Staff +1
+                    17521,  25000,      -- (Staff) Mahogany Pole +1
+                    11477,  50000,      -- (Head) Scholar's Mortarboard +1
+                    11304,  50000,      -- (Body) Scholar's Gown +1
+                    15037,  50000,      -- (Hands) Scholar's Bracers +1
+                    16359,  50000,      -- (Legs) Scholar's Pants +1
+                    11395,  50000,      -- (Feet) Scholar's Loafers +1
+                    15887,  10000,      -- (Neck) Resolute Belt
+                    15885,  10000,      -- (Neck) Spectral Belt
+                    15490,  10000,      -- (Back) Miraculous Cape
+                    15971,  10000,      -- (Earring) Antivenom Earring
+                    15972,  10000,      -- (Earring) Insomnia Earring
+                    15776,  10000,      -- (Ring) Ebullient Ring
+                    15777,  10000,      -- (Ring) Hale Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_SCH =
+                {
+                    17118,  40000,      -- (Staff) Lituus +1
+                    17277,  20000,      -- (Ammunition) Hedgehog Bomb
+                    11083,  50000,      -- (Head) Savant's Bonnet +2
+                    11103,  50000,      -- (Body) Savant's Gown +2
+                    11123,  50000,      -- (Hands) Savant's Bracers +2
+                    11143,  50000,      -- (Legs) Savant's Pants +2
+                    11163,  50000,      -- (Feet) Savant's Loafers +2
+                    19247,  50000,      -- (Ammunition) Savant's Treatise
+                    11620,  50000,      -- (Neck) Savant's Chain
+                    11722,  50000,      -- (Earring) Savant's Earring
+                    10669,  50000,      -- (Head) Argute Mortarboard +2
+                    10689,  50000,      -- (Body) Argute Gown +2
+                    10709,  50000,      -- (Hands) Argute Bracers +2
+                    10729,  50000,      -- (Legs) Argute Pants +2
+                    10749,  50000,      -- (Feet) Argute Loafers +2
+                    11579,  30000,      -- (Neck) Fylgja Torque
+                    11584,  30000,      -- (Neck) Lemegeton Medallion +1
+                    15949,  30000,      -- (Waist) Pythia Sash +1
+                    11743,  30000,      -- (Waist) Searing Sash
+                    27598,  30000,      -- (Back) Dew Silk Cape +1
+                    11560,  30000,      -- (Back) Pedant Cape
+                    11683,  30000,      -- (Earring) Aqua Earring
+                    11682,  30000,      -- (Earring) Snow Earring
+                    13308,  30000,      -- (Ring) Communion Ring
+                    13306,  30000,      -- (Ring) Omniscient Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_SCH =
+                {
+                    21133,  100000,     -- (Club) Sasah Wand +1
+                    21208,  100000,     -- (Staff) Lehbrailg
+                    -- 21362,   30000,      -- (Ammunition) Ombre Tathlum +1
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    11083,  50000,      -- (Head) Savant's Bonnet +2
+                    11103,  50000,      -- (Body) Savant's Gown +2
+                    11123,  50000,      -- (Hands) Savant's Bracers +2
+                    11143,  50000,      -- (Legs) Savant's Pants +2
+                    11163,  50000,      -- (Feet) Savant's Loafers +2
+                    19247,  50000,      -- (Ammunition) Savant's Treatise
+                    11620,  50000,      -- (Neck) Savant's Chain
+                    11722,  50000,      -- (Earring) Savant's Earring
+                    10669,  50000,      -- (Head) Argute Mortarboard +2
+                    10689,  50000,      -- (Body) Argute Gown +2
+                    10709,  50000,      -- (Hands) Argute Bracers +2
+                    10729,  50000,      -- (Legs) Argute Pants +2
+                    10749,  50000,      -- (Feet) Argute Loafers +2
+                    -- 25531,   50000,      -- (Neck) Argute Stole
+                    28455,  50000,      -- (Waist) Ovate Rope
+                    10839,  50000,      -- (Waist) Othila Sash
+                    28596,  50000,      -- (Back) Oretania's Cape +1
+                    28601,  50000,      -- (Back) Seshaw Cape
+                    11683,  30000,      -- (Earring) Aqua Earring
+                    11682,  30000,      -- (Earring) Snow Earring
+                    13308,  30000,      -- (Ring) Communion Ring
+                    13306,  30000,      -- (Ring) Omniscient Ring
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_SCH)
+    elseif (job == xi.job.GEO) then
+        local stock_GEO = {}
+        player:PrintToPlayer(string.format("Andreine : Geomancers are always so spaced out when they come in here!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_GEO =
+                {
+                    17087,  5000,       -- (Club) Maple Wand +1
+                    17137,  5000,       -- (Club) Ash Club +1
+                    17144,  5000,       -- (Club) Bronze Hammer +1
+                    21460,  1000,       -- (Handbell) Matre Bell
+                    12744,  2000,       -- (Gloves) Cuffs +1
+                    12897,  2000,       -- (Legs) Slops +1
+                    12983,  2000,       -- (Feet) Ash Clogs +1
+                    13093,  2000,       -- (Neck) Justice Badge
+                    13190,  2000,       -- (Waist) Heko Obi +1
+                    13605,  2000,       -- (Back) Cape +1
+                    14694,  2000,       -- (Earring) Energy Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    13548,  50000,      -- (Ring) Astral Ring
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_GEO =
+                {
+                    17141,  15000,      -- (Club) Solid Wand
+                    17409,  15000,      -- (Club) Mythril Rod +1
+                    15173,  10000,      -- (Head) Kosshin
+                    13730,  10000,      -- (Body) Frost Robe
+                    12750,  10000,      -- (Hands) New Moon Armlets
+                    12904,  10000,      -- (Legs) Linen Slacks +1
+                    13040,  10000,      -- (Feet) Shoes +1
+                    13102,  5000,       -- (Neck) Paisley Scarf
+                    13233,  5000,       -- (Waist) Gold Obi +1
+                    13610,  5000,       -- (Back) Black Cape +1
+                    14702,  5000,       -- (Earring) Aura Earring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_GEO =
+                {
+                    17427,  25000,      -- (Club) Ebony Wand +1
+                    17435,  25000,      -- (Club) Darksteel Rod +1
+                    12141,  50000,      -- (Head) Ebon Beret
+                    12177,  50000,      -- (Body)  Ebon Frock
+                    12213,  50000,      -- (Hands) Ebon Mitts
+                    12249,  50000,      -- (Legs) Ebon Slops
+                    12285,  50000,      -- (Feet) Ebon Clogs
+                    15887,  10000,      -- (Neck) Resolute Belt
+                    15885,  10000,      -- (Neck) Spectral Belt
+                    15490,  10000,      -- (Back) Miraculous Cape
+                    15971,  10000,      -- (Earring) Antivenom Earring
+                    15972,  10000,      -- (Earring) Insomnia Earring
+                    15776,  10000,      -- (Ring) Ebullient Ring
+                    15777,  10000,      -- (Ring) Hale Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_GEO =
+                {
+                    18875,  40000,      -- (Club) Vodun Mace
+                    17277,  20000,      -- (Ammunition) Hedgehog Bomb
+                    11505,  50000,      -- (Head) Teal Chapeau
+                    13778,  50000,      -- (Body) Teal Saio
+                    12747,  50000,      -- (Hands) Teal Cuffs
+                    14258,  50000,      -- (Legs) Teal Slops
+                    11415,  50000,      -- (Feet) Teal Pigaches
+                    11807,  50000,      -- (Head) Nebula Hat +1
+                    11849,  50000,      -- (Body) Nebula Houppelande +1
+                    11916,  50000,      -- (Hands) Nebula Cuffs +1
+                    11955,  50000,      -- (Legs) Nebula Slops +1
+                    11452,  50000,      -- (Feet) Nebula Pigaches +1
+                    11584,  30000,      -- (Neck) Lemegeton Medallion +1
+                    11743,  30000,      -- (Waist) Searing Sash
+                    11560,  30000,      -- (Back) Pedant Cape
+                    11682,  30000,      -- (Earring) Snow Earring
+                    13306,  30000,      -- (Ring) Omniscient Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_GEO =
+                {
+                    21133,  100000,     -- (Club) Sasah Wand +1
+                    21461,  50000,      -- (Handbell) Filiae Bell
+                    -- 21362,   30000,      -- (Ammunition) Ombre Tathlum +1
+                    27743,  100000,     -- (Head) Temachtiani Headband
+                    27884,  100000,     -- (Body) Temachtiani Shirt
+                    28032,  100000,     -- (Hands) Temachtiani Gloves
+                    28171,  100000,     -- (Legs) Temachtiani Pants
+                    28309,  100000,     -- (Feet) Temachtiani Boots
+                    -- 25537,   50000,      -- (Neck) Bagua Charm
+                    10839,  50000,      -- (Waist) Othila Sash
+                    28601,  50000,      -- (Back) Seshaw Cape
+                    11682,  30000,      -- (Earring) Snow Earring
+                    -- 27574,   50000,      -- (Ring) Shiva Ring
+                    4044,   16667,      -- Atramenterrane (Reforged Artifact Material)
+                    4043,   16667,      -- Lavarion (Reforged Artifact Material)
+                    4042,   16667,      -- Acuex Ore (Reforged Artifact Material)
+                    4030,   16667,      -- Sekishitsu (Reforged Artifact Material)
+                    4045,   16667,      -- Cyclone Cotton (Reforged Artifact Material)
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_GEO)
+    elseif (job == xi.job.RUN) then
+        local stock_RUN = {}
+        player:PrintToPlayer(string.format("Andreine : Mysterious runes? High magical defenses? 100%% Rune Fencer!"),xi.msg.channel.NS_SAY)
+        
+        if (level <= 30) then
+            stock_RUN =
+                {
+                    20781,  5000,       -- (Great Sword) Sowilo Claymore
+                    17307,  2,          -- (Ammunition) Dart
+                    12695,  2000,       -- (Gloves) Bronze Mittens +1
+                    12823,  2000,       -- (Legs) Bronze Subligar +1
+                    12951,  2000,       -- (Feet) Bronze Leggings +1
+                    13069,  2000,       -- (Neck) Leather Gorget +1
+                    13210,  2000,       -- (Waist) Leather Belt +1
+                    13599,  2000,       -- (Back) Rabbit Mantle +1
+                    14695,  2000,       -- (Earring) Hope Earring +1
+                    14694,  2000,       -- (Earring) Energy Earring +1
+                    13492,  2000,       -- (Ring) Copper Ring +1
+                    -- 317, 100000,     -- (Item) Bronze Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 60) then
+            stock_RUN =
+                {
+                    16936,  15000,      -- (Great Sword) Demonic Sword
+                    12538,  10000,      -- (Head) Red Cap +1
+                    12625,  10000,      -- (Body) Gambison +1
+                    12779,  10000,      -- (Hands) Bracers +1
+                    12903,  10000,      -- (Legs) Hose +1
+                    13034,  10000,      -- (Feet) Socks +1
+                    13070,  5000,       -- (Neck) Wolf Gorget +1
+                    13223,  5000,       -- (Waist) Silver Belt +1
+                    13609,  5000,       -- (Back) Wolf Mantle +1
+                    14703,  5000,       -- (Earring) Loyalty Earring +1
+                    13519,  5000,       -- (Ring) Mythril Ring +1
+                    -- 318, 150000,     -- (Item) Crystal Rose (Used to trigger augment application trades)
+                }
+        elseif (level <= 75) then
+            stock_RUN =
+                {
+                    16616,  25000,      -- (Great Sword) Zweihander +1
+                    12120,  50000,      -- (Head) Ebon Mask
+                    12156,  50000,      -- (Body) Ebon Harness
+                    12192,  50000,      -- (Hands) Ebon Gloves
+                    12228,  50000,      -- (Legs) Ebon Brais
+                    12264,  50000,      -- (Feet) Ebon Boots
+                    15523,  10000,      -- (Neck) Chivalrous Chain
+                    15524,  10000,      -- (Neck) Fortified Chain
+                    15521,  10000,      -- (Neck) Tempered Chain
+                    15884,  10000,      -- (Waist) Potent Belt
+                    15493,  10000,      -- (Back) Bushido Cape
+                    13369,  10000,      -- (Earring) Spike Earring
+                    14764,  10000,      -- (Earring) Minuet Earring
+                    13545,  10000,      -- (Ring) Demon's Ring +1
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level < 99) then
+            stock_RUN =
+                {
+                    19166,  40000,      -- (Great Sword) Cratus Sword +1
+                    16074,  50000,      -- (Head) Hydra Mask +1
+                    14538,  50000,      -- (Body) Hydra Mail +1
+                    14950,  50000,      -- (Hands) Hydra Finger Gauntlets +1
+                    15616,  50000,      -- (Legs) Hydra Cuisses +1
+                    15704,  50000,      -- (Feet) Hydra Greaves +1
+                    11803,  50000,      -- (Head) Alcide's Cap +1
+                    11845,  50000,      -- (Body) Alcide's Harness +1
+                    11912,  50000,      -- (Hands) Alcide's Mitts +1
+                    11951,  50000,      -- (Legs) Alcide's Subligar +1
+                    11448,  50000,      -- (Feet) Alcide's Leggings +1
+                    13146,  30000,      -- (Neck) Tern Necklace
+                    15922,  30000,      -- (Waist) Tern Stone
+                    13619,  30000,      -- (Back) Tern Cape
+                    11678,  30000,      -- (Earring) Flame Earring
+                    14630,  30000,      -- (Ring) Flame Ring
+                    -- 139, 250000,     -- (Item) Star Globe (Used to trigger augment application trades)
+                }
+        elseif (level == 99) then
+            stock_RUN =
+                {
+                    20788,  100000,     -- (Great Sword) Hatzoaar Sword +1
+                    20786,  100000,     -- (Great Sword) Thurisaz Blade +1
+                    10435,  100000,     -- (Head) Dux Visor +1
+                    10273,  100000,     -- (Body) Dux Scale Mail +1
+                    10317,  100000,     -- (Hands) Dux Finger Gauntlets +1
+                    10347,  100000,     -- (Legs) Dux Cuisses +1
+                    10364,  100000,     -- (Feet) Dux Greaves +1
+                    -- 25543,   50000,      -- (Neck) Futhark Torque
+                    10831,  50000,      -- (Waist) Paewr Belt
+                    10992,  50000,      -- (Back) Vassal's Mantle
+                    11057,  50000,      -- (Earring) Ghillie Earring +1
+                    10797,  50000,      -- (Ring) Dagaz Ring
+                    10798,  50000,      -- (Ring) Eihwaz Ring
+                    4046,   16667,      -- Corroded Ore (Reforged Artifact Material)
+                    4025,   16667,      -- Snowsteel Sheet (Reforged Artifact Material)
+                    4047,   16667,      -- Redoubtable Silk Thread (Reforged Artifact Material)
+                    3923,   16667,      -- Rhodium Ingot (Reforged Artifact Material)
+                    4029,   16667,      -- Runeweave (Reforged Artifact Material)
+                    -- 321, 350000,     -- (Item) Mythril Bell (Used to trigger augment application trades)
+                }
+        end
+        
+        xi.shop.general(player, stock_RUN)
+    end
+    player:PrintToPlayer(string.format("Andreine's stock changes when you reach levels 31, 61, 76, and 99."),xi.msg.channel.SYSTEM_3)
 end)
 
 return m

--- a/modules/custom/lua/caldera_npc_module/Geography.lua
+++ b/modules/custom/lua/caldera_npc_module/Geography.lua
@@ -1,0 +1,52 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Geography
+-- !pos -91 -2 -91 284
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
+require("modules/module_utils")
+-----------------------------------
+
+
+local m = Module:new("Geography")
+
+local npcToReplaceName = "Geography"
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	
+		player:PrintToPlayer(string.format("Geography : These thrown away abjuration armors might interest you!"),xi.msg.channel.NS_SAY)
+		local stock =
+				{
+					10409,	100000,		-- Iaso Mitra
+					10493,	100000,		-- Iaso Bliaut
+					10543,	100000,		-- Iaso Cuffs
+					10574,	100000,		-- Iaso Tights
+					10640,	100000,		-- Iaso Boots
+					10405,	100000,		-- Huginn Coronet
+					10489,	100000,		-- Huginn Haubert
+					10539,	100000,		-- Huginn Gauntlets
+					10570,	100000,		-- Huginn Hose
+					10636,	100000,		-- Huginn Gambieras
+					10408,	100000,		-- Spurrina Coif
+					10492,	100000,		-- Spurrina Doublet
+					10542,	100000,		-- Spurrina Gages
+					10573,	100000,		-- Spurrina Slops
+					10639,	100000,		-- Spurrina Nails
+					10406,	100000,		-- Tenryu Somen +1
+					10490,	100000,		-- Tenryu Domaru +1
+					10540,	100000,		-- Tenryu Tekko +1
+					10571,	100000,		-- Tenryu Hakama +1
+					10637,	100000,		-- Tenryu Sune-Ate +1
+					10407,	100000,		-- Khepri Bonnet
+					10491,	100000,		-- Khepri Jacket
+					10541,	100000,		-- Khepri Wristbands
+					10572,	100000,		-- Khepri Kecks
+					10638,	100000,		-- Khepri Gamashes
+				}
+	xi.shop.general(player, stock)
+end)
+
+return m 

--- a/modules/custom/lua/caldera_npc_module/Geography.lua
+++ b/modules/custom/lua/caldera_npc_module/Geography.lua
@@ -16,37 +16,37 @@ local m = Module:new("Geography")
 local npcToReplaceName = "Geography"
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	
-		player:PrintToPlayer(string.format("Geography : These thrown away abjuration armors might interest you!"),xi.msg.channel.NS_SAY)
-		local stock =
-				{
-					10409,	100000,		-- Iaso Mitra
-					10493,	100000,		-- Iaso Bliaut
-					10543,	100000,		-- Iaso Cuffs
-					10574,	100000,		-- Iaso Tights
-					10640,	100000,		-- Iaso Boots
-					10405,	100000,		-- Huginn Coronet
-					10489,	100000,		-- Huginn Haubert
-					10539,	100000,		-- Huginn Gauntlets
-					10570,	100000,		-- Huginn Hose
-					10636,	100000,		-- Huginn Gambieras
-					10408,	100000,		-- Spurrina Coif
-					10492,	100000,		-- Spurrina Doublet
-					10542,	100000,		-- Spurrina Gages
-					10573,	100000,		-- Spurrina Slops
-					10639,	100000,		-- Spurrina Nails
-					10406,	100000,		-- Tenryu Somen +1
-					10490,	100000,		-- Tenryu Domaru +1
-					10540,	100000,		-- Tenryu Tekko +1
-					10571,	100000,		-- Tenryu Hakama +1
-					10637,	100000,		-- Tenryu Sune-Ate +1
-					10407,	100000,		-- Khepri Bonnet
-					10491,	100000,		-- Khepri Jacket
-					10541,	100000,		-- Khepri Wristbands
-					10572,	100000,		-- Khepri Kecks
-					10638,	100000,		-- Khepri Gamashes
-				}
-	xi.shop.general(player, stock)
+    
+        player:PrintToPlayer(string.format("Geography : These thrown away abjuration armors might interest you!"),xi.msg.channel.NS_SAY)
+        local stock =
+                {
+                    10409,  100000,     -- Iaso Mitra
+                    10493,  100000,     -- Iaso Bliaut
+                    10543,  100000,     -- Iaso Cuffs
+                    10574,  100000,     -- Iaso Tights
+                    10640,  100000,     -- Iaso Boots
+                    10405,  100000,     -- Huginn Coronet
+                    10489,  100000,     -- Huginn Haubert
+                    10539,  100000,     -- Huginn Gauntlets
+                    10570,  100000,     -- Huginn Hose
+                    10636,  100000,     -- Huginn Gambieras
+                    10408,  100000,     -- Spurrina Coif
+                    10492,  100000,     -- Spurrina Doublet
+                    10542,  100000,     -- Spurrina Gages
+                    10573,  100000,     -- Spurrina Slops
+                    10639,  100000,     -- Spurrina Nails
+                    10406,  100000,     -- Tenryu Somen +1
+                    10490,  100000,     -- Tenryu Domaru +1
+                    10540,  100000,     -- Tenryu Tekko +1
+                    10571,  100000,     -- Tenryu Hakama +1
+                    10637,  100000,     -- Tenryu Sune-Ate +1
+                    10407,  100000,     -- Khepri Bonnet
+                    10491,  100000,     -- Khepri Jacket
+                    10541,  100000,     -- Khepri Wristbands
+                    10572,  100000,     -- Khepri Kecks
+                    10638,  100000,     -- Khepri Gamashes
+                }
+    xi.shop.general(player, stock)
 end)
 
 return m 

--- a/modules/custom/lua/caldera_npc_module/Hestefa.lua
+++ b/modules/custom/lua/caldera_npc_module/Hestefa.lua
@@ -1,0 +1,168 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Hestefa
+-- RSE Merchant NPC
+-- !pos -114.7442 -2.1500 -99.5595 284
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
+require("modules/module_utils")
+-----------------------------------
+
+
+local m = Module:new("Hestefa")
+
+local npcToReplaceName = "Hestefa"
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	player:PrintToPlayer(string.format("Hestefa : Get your Race Specific Equipment here!"),xi.msg.channel.NS_SAY)
+	
+	local stockElvaanM =
+	{
+		12656, 5000,			-- Magna Jerkin
+		12763, 5000,			-- Magna Gauntlets
+		12873, 5000,			-- Magna M Chausses
+		13017, 5000,			-- Magna M Ledelsens
+		18249, 5000,			-- Olibanum Sachet
+		13252, 10000,			-- Forest Belt
+		13257, 10000,			-- Forest Stone
+		14835, 15000,			-- Wood Gauntlets
+		14200, 15000,			-- Wood M Ledelsens
+		13267, 20000,			-- Forest Rope
+		13262, 20000,			-- Forest Sash
+		11899, 25000,			-- Weald Gages
+		11904, 25000,			-- Thicket Gages
+	}
+	
+	local stockElvaanF =
+	{
+		12657, 5000,			-- Magna Bodice
+		12764, 5000,			-- Magna Gloves
+		12874, 5000,			-- Magna F Chausses
+		13018, 5000,			-- Magna F Ledelsens
+		18250, 5000,			-- Attar Sachet
+		13252, 10000,			-- Forest Belt
+		13257, 10000,			-- Forest Stone
+		14836, 15000,			-- Wood Gloves 
+		14201, 15000,			-- Wood F Ledelsens
+		13267, 20000,			-- Forest Rope
+		13262, 20000,			-- Forest Sash
+		11899, 25000,			-- Weald Gages
+		11904, 25000,			-- Thicket Gages
+	}
+	
+    local stockHumeM =
+    {
+		12654, 5000,			-- Custom Tunic
+		12761, 5000,			-- Custom M Gloves
+		12871, 5000,			-- Custom Slacks
+		13015, 5000,			-- Custom M Boots
+		18247, 5000,			-- Balm Sachet
+		13251, 10000,			-- Ocean Belt
+		13256, 10000,			-- Ocean Stone
+		14833, 15000,			-- Marine M Gloves
+		14198, 15000,			-- Marine M Boots
+		13266, 20000,			-- Ocean Rope
+		13261, 20000,			-- Ocean Sash
+		11903, 25000,			-- Tide Gages
+		11898, 25000,			-- Wave Gages
+    }
+	
+	local stockHumeF =
+    {
+		12655, 5000,			-- Custom Vest
+		12762, 5000,			-- Custom F Gloves
+		12872, 5000,			-- Custom Pants
+		13016, 5000,			-- Custom F Boots
+		18248, 5000,			-- Millefleurs Sachet
+		13251, 10000,			-- Ocean Belt
+		13256, 10000,			-- Ocean Stone
+		14834, 15000,			-- Marine F Gloves
+		14199, 15000,			-- Marine F Boots
+		13266, 20000,			-- Ocean Rope
+		13261, 20000,			-- Ocean Sash
+		11903, 25000,			-- Tide Gages
+		11898, 25000,			-- Wave Gages
+    }
+	
+	local stockTaruM =
+	{
+		12658, 5000,			-- Wonder Kaftan
+		12765, 5000,			-- Wonder Mitts
+		12875, 5000,			-- Wonder Braccae
+		13019, 5000,			-- Wonder Clomps
+		18251, 5000,			-- Sweet Sachet
+		13253, 10000,			-- Steppe Belt
+		13258, 10000,			-- Steppe Stone
+		14837, 15000,			-- Creek M Mitts
+		14202, 15000,			-- Creek M Clomps
+		13268, 20000,			-- Steppe Rope
+		13263, 20000,			-- Steppe Sash
+		11905, 25000,			-- Brook Gages
+		11900, 25000,			-- Savanna Gages
+	}
+	
+	local stockTaruF =
+	{
+		12658, 5000,			-- Wonder Kaftan
+		12765, 5000,			-- Wonder Mitts
+		12875, 5000,			-- Wonder Braccae
+		13019, 5000,			-- Wonder Clomps
+		18251, 5000,			-- Sweet Sachet
+		13253, 10000,			-- Steppe Belt
+		13258, 10000,			-- Steppe Stone
+		14838, 15000,			-- Creek F Mitts
+		14023, 15000,			-- Creek F Clomps
+		13268, 20000,			-- Steppe Rope
+		13263, 20000,			-- Steppe Sash
+		11905, 25000,			-- Brook Gages
+		11900, 25000,			-- Savanna Gages
+	}
+	
+	local stockMithra =
+	{
+		12659, 5000,			-- Savage Separates
+		12766, 5000,			-- Savage Gauntlets
+		12876, 5000,			-- Savage Loincloth
+		13020, 5000,			-- Savage Gaiters
+		18252, 5000,			-- Civet Sachet
+		13254, 10000,			-- Jungle Belt
+		13259, 10000,			-- Jungle Stone
+		14839, 15000,			-- River Gauntlets
+		14204, 15000,			-- River Gaiters
+		13269, 20000,			-- Jungle Rope
+		13264, 20000,			-- Jungle Sash
+		11901, 25000,			-- Tropic Gages
+		11906, 25000,			-- Wild Gages
+	}
+	
+	local stockGalka =
+	{
+		12660, 5000,			-- Elder's Surcoat
+		12767, 5000,			-- Elder's Bracers
+		12877, 5000,			-- Elder's Braguette
+		13021, 5000,			-- Elder's Sandals
+		18253, 5000,			-- Musk Sachet
+		13255, 10000,			-- Desert Belt
+		13260, 10000,			-- Desert Stone
+		14840, 15000,			-- Dune Bracers
+		14205, 15000,			-- Dune Sandals
+		13270, 20000,			-- Desert Rope
+		13265, 20000,			-- Desert Sash
+		11902, 25000,			-- Strand Gages
+		11907, 25000,			-- Torrid Gages
+	}
+
+	local race = {xi.race.ELVAAN_M, xi.race.ELVAAN_F, xi.race.HUME_M, xi.race.HUME_F, xi.race.TARU_M, xi.race.TARU_F, xi.race.MITHRA, xi.race.GALKA}
+	local shopStock = {stockElvaanM, stockElvaanF, stockHumeM, stockHumeF, stockTaruM, stockTaruF, stockMithra, stockGalka}
+	
+	for i = 1, #race do
+		if (player:getRace() == race[i]) then
+			xi.shop.general(player, shopStock[i])
+		end
+	end
+end)
+
+return m 

--- a/modules/custom/lua/caldera_npc_module/Hestefa.lua
+++ b/modules/custom/lua/caldera_npc_module/Hestefa.lua
@@ -17,152 +17,152 @@ local m = Module:new("Hestefa")
 local npcToReplaceName = "Hestefa"
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	player:PrintToPlayer(string.format("Hestefa : Get your Race Specific Equipment here!"),xi.msg.channel.NS_SAY)
-	
-	local stockElvaanM =
-	{
-		12656, 5000,			-- Magna Jerkin
-		12763, 5000,			-- Magna Gauntlets
-		12873, 5000,			-- Magna M Chausses
-		13017, 5000,			-- Magna M Ledelsens
-		18249, 5000,			-- Olibanum Sachet
-		13252, 10000,			-- Forest Belt
-		13257, 10000,			-- Forest Stone
-		14835, 15000,			-- Wood Gauntlets
-		14200, 15000,			-- Wood M Ledelsens
-		13267, 20000,			-- Forest Rope
-		13262, 20000,			-- Forest Sash
-		11899, 25000,			-- Weald Gages
-		11904, 25000,			-- Thicket Gages
-	}
-	
-	local stockElvaanF =
-	{
-		12657, 5000,			-- Magna Bodice
-		12764, 5000,			-- Magna Gloves
-		12874, 5000,			-- Magna F Chausses
-		13018, 5000,			-- Magna F Ledelsens
-		18250, 5000,			-- Attar Sachet
-		13252, 10000,			-- Forest Belt
-		13257, 10000,			-- Forest Stone
-		14836, 15000,			-- Wood Gloves 
-		14201, 15000,			-- Wood F Ledelsens
-		13267, 20000,			-- Forest Rope
-		13262, 20000,			-- Forest Sash
-		11899, 25000,			-- Weald Gages
-		11904, 25000,			-- Thicket Gages
-	}
-	
+    player:PrintToPlayer(string.format("Hestefa : Get your Race Specific Equipment here!"),xi.msg.channel.NS_SAY)
+    
+    local stockElvaanM =
+    {
+        12656, 5000,            -- Magna Jerkin
+        12763, 5000,            -- Magna Gauntlets
+        12873, 5000,            -- Magna M Chausses
+        13017, 5000,            -- Magna M Ledelsens
+        18249, 5000,            -- Olibanum Sachet
+        13252, 10000,           -- Forest Belt
+        13257, 10000,           -- Forest Stone
+        14835, 15000,           -- Wood Gauntlets
+        14200, 15000,           -- Wood M Ledelsens
+        13267, 20000,           -- Forest Rope
+        13262, 20000,           -- Forest Sash
+        11899, 25000,           -- Weald Gages
+        11904, 25000,           -- Thicket Gages
+    }
+    
+    local stockElvaanF =
+    {
+        12657, 5000,            -- Magna Bodice
+        12764, 5000,            -- Magna Gloves
+        12874, 5000,            -- Magna F Chausses
+        13018, 5000,            -- Magna F Ledelsens
+        18250, 5000,            -- Attar Sachet
+        13252, 10000,           -- Forest Belt
+        13257, 10000,           -- Forest Stone
+        14836, 15000,           -- Wood Gloves 
+        14201, 15000,           -- Wood F Ledelsens
+        13267, 20000,           -- Forest Rope
+        13262, 20000,           -- Forest Sash
+        11899, 25000,           -- Weald Gages
+        11904, 25000,           -- Thicket Gages
+    }
+    
     local stockHumeM =
     {
-		12654, 5000,			-- Custom Tunic
-		12761, 5000,			-- Custom M Gloves
-		12871, 5000,			-- Custom Slacks
-		13015, 5000,			-- Custom M Boots
-		18247, 5000,			-- Balm Sachet
-		13251, 10000,			-- Ocean Belt
-		13256, 10000,			-- Ocean Stone
-		14833, 15000,			-- Marine M Gloves
-		14198, 15000,			-- Marine M Boots
-		13266, 20000,			-- Ocean Rope
-		13261, 20000,			-- Ocean Sash
-		11903, 25000,			-- Tide Gages
-		11898, 25000,			-- Wave Gages
+        12654, 5000,            -- Custom Tunic
+        12761, 5000,            -- Custom M Gloves
+        12871, 5000,            -- Custom Slacks
+        13015, 5000,            -- Custom M Boots
+        18247, 5000,            -- Balm Sachet
+        13251, 10000,           -- Ocean Belt
+        13256, 10000,           -- Ocean Stone
+        14833, 15000,           -- Marine M Gloves
+        14198, 15000,           -- Marine M Boots
+        13266, 20000,           -- Ocean Rope
+        13261, 20000,           -- Ocean Sash
+        11903, 25000,           -- Tide Gages
+        11898, 25000,           -- Wave Gages
     }
-	
-	local stockHumeF =
+    
+    local stockHumeF =
     {
-		12655, 5000,			-- Custom Vest
-		12762, 5000,			-- Custom F Gloves
-		12872, 5000,			-- Custom Pants
-		13016, 5000,			-- Custom F Boots
-		18248, 5000,			-- Millefleurs Sachet
-		13251, 10000,			-- Ocean Belt
-		13256, 10000,			-- Ocean Stone
-		14834, 15000,			-- Marine F Gloves
-		14199, 15000,			-- Marine F Boots
-		13266, 20000,			-- Ocean Rope
-		13261, 20000,			-- Ocean Sash
-		11903, 25000,			-- Tide Gages
-		11898, 25000,			-- Wave Gages
+        12655, 5000,            -- Custom Vest
+        12762, 5000,            -- Custom F Gloves
+        12872, 5000,            -- Custom Pants
+        13016, 5000,            -- Custom F Boots
+        18248, 5000,            -- Millefleurs Sachet
+        13251, 10000,           -- Ocean Belt
+        13256, 10000,           -- Ocean Stone
+        14834, 15000,           -- Marine F Gloves
+        14199, 15000,           -- Marine F Boots
+        13266, 20000,           -- Ocean Rope
+        13261, 20000,           -- Ocean Sash
+        11903, 25000,           -- Tide Gages
+        11898, 25000,           -- Wave Gages
     }
-	
-	local stockTaruM =
-	{
-		12658, 5000,			-- Wonder Kaftan
-		12765, 5000,			-- Wonder Mitts
-		12875, 5000,			-- Wonder Braccae
-		13019, 5000,			-- Wonder Clomps
-		18251, 5000,			-- Sweet Sachet
-		13253, 10000,			-- Steppe Belt
-		13258, 10000,			-- Steppe Stone
-		14837, 15000,			-- Creek M Mitts
-		14202, 15000,			-- Creek M Clomps
-		13268, 20000,			-- Steppe Rope
-		13263, 20000,			-- Steppe Sash
-		11905, 25000,			-- Brook Gages
-		11900, 25000,			-- Savanna Gages
-	}
-	
-	local stockTaruF =
-	{
-		12658, 5000,			-- Wonder Kaftan
-		12765, 5000,			-- Wonder Mitts
-		12875, 5000,			-- Wonder Braccae
-		13019, 5000,			-- Wonder Clomps
-		18251, 5000,			-- Sweet Sachet
-		13253, 10000,			-- Steppe Belt
-		13258, 10000,			-- Steppe Stone
-		14838, 15000,			-- Creek F Mitts
-		14023, 15000,			-- Creek F Clomps
-		13268, 20000,			-- Steppe Rope
-		13263, 20000,			-- Steppe Sash
-		11905, 25000,			-- Brook Gages
-		11900, 25000,			-- Savanna Gages
-	}
-	
-	local stockMithra =
-	{
-		12659, 5000,			-- Savage Separates
-		12766, 5000,			-- Savage Gauntlets
-		12876, 5000,			-- Savage Loincloth
-		13020, 5000,			-- Savage Gaiters
-		18252, 5000,			-- Civet Sachet
-		13254, 10000,			-- Jungle Belt
-		13259, 10000,			-- Jungle Stone
-		14839, 15000,			-- River Gauntlets
-		14204, 15000,			-- River Gaiters
-		13269, 20000,			-- Jungle Rope
-		13264, 20000,			-- Jungle Sash
-		11901, 25000,			-- Tropic Gages
-		11906, 25000,			-- Wild Gages
-	}
-	
-	local stockGalka =
-	{
-		12660, 5000,			-- Elder's Surcoat
-		12767, 5000,			-- Elder's Bracers
-		12877, 5000,			-- Elder's Braguette
-		13021, 5000,			-- Elder's Sandals
-		18253, 5000,			-- Musk Sachet
-		13255, 10000,			-- Desert Belt
-		13260, 10000,			-- Desert Stone
-		14840, 15000,			-- Dune Bracers
-		14205, 15000,			-- Dune Sandals
-		13270, 20000,			-- Desert Rope
-		13265, 20000,			-- Desert Sash
-		11902, 25000,			-- Strand Gages
-		11907, 25000,			-- Torrid Gages
-	}
+    
+    local stockTaruM =
+    {
+        12658, 5000,            -- Wonder Kaftan
+        12765, 5000,            -- Wonder Mitts
+        12875, 5000,            -- Wonder Braccae
+        13019, 5000,            -- Wonder Clomps
+        18251, 5000,            -- Sweet Sachet
+        13253, 10000,           -- Steppe Belt
+        13258, 10000,           -- Steppe Stone
+        14837, 15000,           -- Creek M Mitts
+        14202, 15000,           -- Creek M Clomps
+        13268, 20000,           -- Steppe Rope
+        13263, 20000,           -- Steppe Sash
+        11905, 25000,           -- Brook Gages
+        11900, 25000,           -- Savanna Gages
+    }
+    
+    local stockTaruF =
+    {
+        12658, 5000,            -- Wonder Kaftan
+        12765, 5000,            -- Wonder Mitts
+        12875, 5000,            -- Wonder Braccae
+        13019, 5000,            -- Wonder Clomps
+        18251, 5000,            -- Sweet Sachet
+        13253, 10000,           -- Steppe Belt
+        13258, 10000,           -- Steppe Stone
+        14838, 15000,           -- Creek F Mitts
+        14023, 15000,           -- Creek F Clomps
+        13268, 20000,           -- Steppe Rope
+        13263, 20000,           -- Steppe Sash
+        11905, 25000,           -- Brook Gages
+        11900, 25000,           -- Savanna Gages
+    }
+    
+    local stockMithra =
+    {
+        12659, 5000,            -- Savage Separates
+        12766, 5000,            -- Savage Gauntlets
+        12876, 5000,            -- Savage Loincloth
+        13020, 5000,            -- Savage Gaiters
+        18252, 5000,            -- Civet Sachet
+        13254, 10000,           -- Jungle Belt
+        13259, 10000,           -- Jungle Stone
+        14839, 15000,           -- River Gauntlets
+        14204, 15000,           -- River Gaiters
+        13269, 20000,           -- Jungle Rope
+        13264, 20000,           -- Jungle Sash
+        11901, 25000,           -- Tropic Gages
+        11906, 25000,           -- Wild Gages
+    }
+    
+    local stockGalka =
+    {
+        12660, 5000,            -- Elder's Surcoat
+        12767, 5000,            -- Elder's Bracers
+        12877, 5000,            -- Elder's Braguette
+        13021, 5000,            -- Elder's Sandals
+        18253, 5000,            -- Musk Sachet
+        13255, 10000,           -- Desert Belt
+        13260, 10000,           -- Desert Stone
+        14840, 15000,           -- Dune Bracers
+        14205, 15000,           -- Dune Sandals
+        13270, 20000,           -- Desert Rope
+        13265, 20000,           -- Desert Sash
+        11902, 25000,           -- Strand Gages
+        11907, 25000,           -- Torrid Gages
+    }
 
-	local race = {xi.race.ELVAAN_M, xi.race.ELVAAN_F, xi.race.HUME_M, xi.race.HUME_F, xi.race.TARU_M, xi.race.TARU_F, xi.race.MITHRA, xi.race.GALKA}
-	local shopStock = {stockElvaanM, stockElvaanF, stockHumeM, stockHumeF, stockTaruM, stockTaruF, stockMithra, stockGalka}
-	
-	for i = 1, #race do
-		if (player:getRace() == race[i]) then
-			xi.shop.general(player, shopStock[i])
-		end
-	end
+    local race = {xi.race.ELVAAN_M, xi.race.ELVAAN_F, xi.race.HUME_M, xi.race.HUME_F, xi.race.TARU_M, xi.race.TARU_F, xi.race.MITHRA, xi.race.GALKA}
+    local shopStock = {stockElvaanM, stockElvaanF, stockHumeM, stockHumeF, stockTaruM, stockTaruF, stockMithra, stockGalka}
+    
+    for i = 1, #race do
+        if (player:getRace() == race[i]) then
+            xi.shop.general(player, shopStock[i])
+        end
+    end
 end)
 
 return m 

--- a/modules/custom/lua/caldera_npc_module/History.lua
+++ b/modules/custom/lua/caldera_npc_module/History.lua
@@ -17,142 +17,142 @@ local npcToReplaceName = "History"
 
 
 local acceptedTrades = {{3690, 200000}, -- Fighter Board
-						{3689, 250000}, -- Wizardess Board
-						{3686, 300000}, -- Duelist Board
-						{3684, 350000}, -- Princess Board
-						{3691, 400000}, -- Guardian Board
-						{3685, 500000}} -- Empress Board
-						
+                        {3689, 250000}, -- Wizardess Board
+                        {3686, 300000}, -- Duelist Board
+                        {3684, 350000}, -- Princess Board
+                        {3691, 400000}, -- Guardian Board
+                        {3685, 500000}} -- Empress Board
+                        
 local stock_t1_locked = {
-	8992,  250000,			-- Jester Malatrix's Shard
-	8990,  250000,			-- Largantua's Shard
-	8977,  250000,			-- Ironhorn Baldurno's Horn
-	8981,  250000,			-- Abyssdiver's Feather
-	8976,  250000,			-- Prickly Pitriv's Thread
-	8988,  250000,			-- Waraxe Beak's Hide
-	8982,  250000,			-- Intuila's Hide
-	8983,  250000,			-- Emperor Arthro's Shell
-	8707,  500000,			-- Raaz Hide
-	8709,  500000, 			-- Raaz Tusk
-	2169,  1000000,			-- Cerberus Hide
-	4027,  1000000,			-- Spool of Akaso Thread
-	722,   1000000,			-- Divine Log
-	8725,  1000000,			-- Exalted Log
-	702,   1000000,			-- Ebony Log
-	4018,  1000000,			-- Guatambu Log
-	8747,  1000000,			-- Chuck of Ra'Kaznar Ore
-	8723,  1000000,			-- Chunk of Beryllium Ore
-	4058,  1000000,			-- Chunk of Bismuth Ore
-	3922,  1000000,			-- Chunk of Rhodium Ore
-	9075,  3000000,			-- Chunk of Vulcanite Ore
-	747,   2000000,			-- Orichalcum Ingot
-	2275,  2000000,			-- Scintillant Ingot
-	8724,  2000000,			-- Beryllium Ingot
-	8748,  2000000,			-- Ra'Kaznar Ingot
-	3923,  2000000,			-- Rhodium Ingot
-	8704,  2000000,			-- Bismuth Ingot
-	657,   2000000,			-- Lump of Tama-Hagane
-	8751,  2000000,			-- Square of Ancestral Cloth
-	836,   2000000,			-- Square of Damascene Cloth
-	4028,  2000000,			-- Square of Akaso Cloth
-	723,   2000000,			-- Piece of Divine Lumber
-	8726,  2000000,			-- Piece of Exalted Lumber
-	719,   2000000,			-- Piece of Ebony Lumber
-	4019,  2000000,			-- Piece of Guatambu Lumber
-	21392, 5000000,			-- Animator Z
-	21393, 5000000,			-- Arasy Sachet
+    8992,  250000,          -- Jester Malatrix's Shard
+    8990,  250000,          -- Largantua's Shard
+    8977,  250000,          -- Ironhorn Baldurno's Horn
+    8981,  250000,          -- Abyssdiver's Feather
+    8976,  250000,          -- Prickly Pitriv's Thread
+    8988,  250000,          -- Waraxe Beak's Hide
+    8982,  250000,          -- Intuila's Hide
+    8983,  250000,          -- Emperor Arthro's Shell
+    8707,  500000,          -- Raaz Hide
+    8709,  500000,          -- Raaz Tusk
+    2169,  1000000,         -- Cerberus Hide
+    4027,  1000000,         -- Spool of Akaso Thread
+    722,   1000000,         -- Divine Log
+    8725,  1000000,         -- Exalted Log
+    702,   1000000,         -- Ebony Log
+    4018,  1000000,         -- Guatambu Log
+    8747,  1000000,         -- Chuck of Ra'Kaznar Ore
+    8723,  1000000,         -- Chunk of Beryllium Ore
+    4058,  1000000,         -- Chunk of Bismuth Ore
+    3922,  1000000,         -- Chunk of Rhodium Ore
+    9075,  3000000,         -- Chunk of Vulcanite Ore
+    747,   2000000,         -- Orichalcum Ingot
+    2275,  2000000,         -- Scintillant Ingot
+    8724,  2000000,         -- Beryllium Ingot
+    8748,  2000000,         -- Ra'Kaznar Ingot
+    3923,  2000000,         -- Rhodium Ingot
+    8704,  2000000,         -- Bismuth Ingot
+    657,   2000000,         -- Lump of Tama-Hagane
+    8751,  2000000,         -- Square of Ancestral Cloth
+    836,   2000000,         -- Square of Damascene Cloth
+    4028,  2000000,         -- Square of Akaso Cloth
+    723,   2000000,         -- Piece of Divine Lumber
+    8726,  2000000,         -- Piece of Exalted Lumber
+    719,   2000000,         -- Piece of Ebony Lumber
+    4019,  2000000,         -- Piece of Guatambu Lumber
+    21392, 5000000,         -- Animator Z
+    21393, 5000000,         -- Arasy Sachet
 }
-	
+    
 local stock_t2_locked = {
-	9249, 1500000,			-- Chunk of Ruthenium Ore
-	9247, 1500000,			-- Chunk of Niobium Ore
-	8721, 1500000,			-- Chunk of Hepatizon Ore
-	9251, 1500000,			-- Spool of Khoma Thread
-	1313, 2500000,			-- Locks of Siren's hair
-	8727, 2500000,			-- Sif's Lock
-	3449, 2500000,			-- Celaeno's Cloth
-	3544, 2500000,			-- Penelope's Cloth
-	3549, 500000,			-- Vial of Belladonna sap
-	3926, 4000000,			-- Urunday Log
-	9245, 4000000,			-- Cypress Log
-	3547, 5000000,			-- Sealord Skin
-	4080, 5000000,			-- Moonbow Urushi
-	4081, 5000000,			-- Moonbow Stone
-	4077, 5000000,			-- Piece of Moonbow Steel
-	4079, 5000000,			-- Square of Moonbow Leather
-	4078, 5000000,			-- Bolt of Moonbow Cloth
-	9252, 5000000,			-- Square of Khoma Cloth
-	8720, 5000000,			-- Maliyakaleya Orb
-	9250, 7500000,			-- Ruthenium Ingot
-	9248, 7500000,			-- Niobium Ingot
-	8722, 7500000,			-- Hepatizon Ingot
-	3927, 7500000,			-- Piece of Urunday Lumber
-	9246, 7500000,			-- Piece of Cypress Lumber
-	2359, 7500000,			-- Star Sapphire
-	1409, 7500000, 			-- Spool of Siren's Macrame
-	8728, 7500000,			-- Spool of Sif's Macrame
-	4014, 7500000,			-- Yggdreant Bole
-	766,  10000000,			-- Ormolu Ingot
-	8719, 10000000,			-- Piece of Maliyakaleya Coral
-	9062, 10000000,			-- Dark Matter
-	9003, 15000000,			-- Chunk of Plovid Flesh
-	3548, 15000000,			-- Square of Sealord Leather
-	9004, 15000000,			-- Macuil Plating
-	9006, 15000000,			-- Defiant Scarf
-	9061, 15000000,			-- Hades' Claw
-	9063, 15000000,			-- Tartarian Soul
+    9249, 1500000,          -- Chunk of Ruthenium Ore
+    9247, 1500000,          -- Chunk of Niobium Ore
+    8721, 1500000,          -- Chunk of Hepatizon Ore
+    9251, 1500000,          -- Spool of Khoma Thread
+    1313, 2500000,          -- Locks of Siren's hair
+    8727, 2500000,          -- Sif's Lock
+    3449, 2500000,          -- Celaeno's Cloth
+    3544, 2500000,          -- Penelope's Cloth
+    3549, 500000,           -- Vial of Belladonna sap
+    3926, 4000000,          -- Urunday Log
+    9245, 4000000,          -- Cypress Log
+    3547, 5000000,          -- Sealord Skin
+    4080, 5000000,          -- Moonbow Urushi
+    4081, 5000000,          -- Moonbow Stone
+    4077, 5000000,          -- Piece of Moonbow Steel
+    4079, 5000000,          -- Square of Moonbow Leather
+    4078, 5000000,          -- Bolt of Moonbow Cloth
+    9252, 5000000,          -- Square of Khoma Cloth
+    8720, 5000000,          -- Maliyakaleya Orb
+    9250, 7500000,          -- Ruthenium Ingot
+    9248, 7500000,          -- Niobium Ingot
+    8722, 7500000,          -- Hepatizon Ingot
+    3927, 7500000,          -- Piece of Urunday Lumber
+    9246, 7500000,          -- Piece of Cypress Lumber
+    2359, 7500000,          -- Star Sapphire
+    1409, 7500000,          -- Spool of Siren's Macrame
+    8728, 7500000,          -- Spool of Sif's Macrame
+    4014, 7500000,          -- Yggdreant Bole
+    766,  10000000,         -- Ormolu Ingot
+    8719, 10000000,         -- Piece of Maliyakaleya Coral
+    9062, 10000000,         -- Dark Matter
+    9003, 15000000,         -- Chunk of Plovid Flesh
+    3548, 15000000,         -- Square of Sealord Leather
+    9004, 15000000,         -- Macuil Plating
+    9006, 15000000,         -- Defiant Scarf
+    9061, 15000000,         -- Hades' Claw
+    9063, 15000000,         -- Tartarian Soul
 }
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	player:PrintToPlayer(string.format("History : I will provide rewards for particular pieces of historical furniture you find on notorious monsters!"),xi.msg.channel.NS_SAY)
-	player:PrintToPlayer(string.format("History : I also sell advanced materials to proven heroes!"),xi.msg.channel.NS_SAY)
+    player:PrintToPlayer(string.format("History : I will provide rewards for particular pieces of historical furniture you find on notorious monsters!"),xi.msg.channel.NS_SAY)
+    player:PrintToPlayer(string.format("History : I also sell advanced materials to proven heroes!"),xi.msg.channel.NS_SAY)
 end)
 
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrade",  npcToReplaceName), function(player, npc, trade)
-	local playerLvl = player:getMainLvl() + player:getItemLevel()
-	local t1Unlock = 0
-	local t2Unlock = 0
-	local valueTotal = 0
-	local tradeQty = {}
-	
-	-- Check for furnishings included in trade
-	for i = 1, #acceptedTrades do
-		if (npcUtil.tradeHas(trade, {acceptedTrades[i][1]})) then
-			tradeQty[i] = trade:getItemQty(acceptedTrades[i][1])
-			valueTotal = valueTotal + (tradeQty[i] * acceptedTrades[i][2])
-			-- printf("History.lua onTrade  TRADE %i QTY: [%i]  TOTAL VALUE: [%i]", i, tradeQty[i], valueTotal)
-		end
-	end
-		
-	if (valueTotal > 0 and trade:getGil() == 0) then
-		player:PrintToPlayer(string.format("History : Here's %i gil for your valuable finds!", valueTotal),xi.msg.channel.NS_SAY)
-		player:tradeComplete()
-		player:addGil(valueTotal)
-	elseif (valueTotal == 0 and trade:getGil() == 0) then
-		player:PrintToPlayer(string.format("History : Sorry, I can't take those items.", valueTotal),xi.msg.channel.NS_SAY)
-	end
-	
-	-- Shops
-	if (valueTotal == 0 and trade:getGil() > 0) then
-		if (player:getCharVar("KillCounter_AbsoluteVirtue") >= 1) then
-			t1Unlock = 1
-		end
-		
-		if (player:getCharVar("KillCounter_Akvan") >= 1 and player:getCharVar("KillCounter_Kaggen") >= 1 and player:getCharVar("KillCounter_Pil") >= 1) then
-			t2Unlock = 1
-		end
-		
-		if (trade:getGil() == 2 and t1Unlock == 1 and t2Unlock == 1) then
-			player:PrintToPlayer(string.format("History : I sell advanced materials to proven heroes! Here's the second page of my shop!"),xi.msg.channel.NS_SAY)
-			xi.shop.general(player, stock_t2_locked)
-		elseif (trade:getGil() == 1 and t1Unlock == 1) then
-			player:PrintToPlayer(string.format("History : I sell advanced materials to proven heroes! Here's the first page of my shop!"),xi.msg.channel.NS_SAY)
-			xi.shop.general(player, stock_t1_locked)
-		else
-			player:PrintToPlayer(string.format("History : Looks like there's still some killing to be done before I can sell anything to you."),xi.msg.channel.NS_SAY)
-		end
-	end
+    local playerLvl = player:getMainLvl() + player:getItemLevel()
+    local t1Unlock = 0
+    local t2Unlock = 0
+    local valueTotal = 0
+    local tradeQty = {}
+    
+    -- Check for furnishings included in trade
+    for i = 1, #acceptedTrades do
+        if (npcUtil.tradeHas(trade, {acceptedTrades[i][1]})) then
+            tradeQty[i] = trade:getItemQty(acceptedTrades[i][1])
+            valueTotal = valueTotal + (tradeQty[i] * acceptedTrades[i][2])
+            -- printf("History.lua onTrade  TRADE %i QTY: [%i]  TOTAL VALUE: [%i]", i, tradeQty[i], valueTotal)
+        end
+    end
+        
+    if (valueTotal > 0 and trade:getGil() == 0) then
+        player:PrintToPlayer(string.format("History : Here's %i gil for your valuable finds!", valueTotal),xi.msg.channel.NS_SAY)
+        player:tradeComplete()
+        player:addGil(valueTotal)
+    elseif (valueTotal == 0 and trade:getGil() == 0) then
+        player:PrintToPlayer(string.format("History : Sorry, I can't take those items.", valueTotal),xi.msg.channel.NS_SAY)
+    end
+    
+    -- Shops
+    if (valueTotal == 0 and trade:getGil() > 0) then
+        if (player:getCharVar("KillCounter_AbsoluteVirtue") >= 1) then
+            t1Unlock = 1
+        end
+        
+        if (player:getCharVar("KillCounter_Akvan") >= 1 and player:getCharVar("KillCounter_Kaggen") >= 1 and player:getCharVar("KillCounter_Pil") >= 1) then
+            t2Unlock = 1
+        end
+        
+        if (trade:getGil() == 2 and t1Unlock == 1 and t2Unlock == 1) then
+            player:PrintToPlayer(string.format("History : I sell advanced materials to proven heroes! Here's the second page of my shop!"),xi.msg.channel.NS_SAY)
+            xi.shop.general(player, stock_t2_locked)
+        elseif (trade:getGil() == 1 and t1Unlock == 1) then
+            player:PrintToPlayer(string.format("History : I sell advanced materials to proven heroes! Here's the first page of my shop!"),xi.msg.channel.NS_SAY)
+            xi.shop.general(player, stock_t1_locked)
+        else
+            player:PrintToPlayer(string.format("History : Looks like there's still some killing to be done before I can sell anything to you."),xi.msg.channel.NS_SAY)
+        end
+    end
 end)
 
 return m 

--- a/modules/custom/lua/caldera_npc_module/History.lua
+++ b/modules/custom/lua/caldera_npc_module/History.lua
@@ -1,0 +1,158 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: History
+-- !pos -116.250 -3.650 -90.147 284
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
+require("scripts/globals/missions")
+require("modules/module_utils")
+-----------------------------------
+
+local m = Module:new("History")
+
+local npcToReplaceName = "History"
+
+
+local acceptedTrades = {{3690, 200000}, -- Fighter Board
+						{3689, 250000}, -- Wizardess Board
+						{3686, 300000}, -- Duelist Board
+						{3684, 350000}, -- Princess Board
+						{3691, 400000}, -- Guardian Board
+						{3685, 500000}} -- Empress Board
+						
+local stock_t1_locked = {
+	8992,  250000,			-- Jester Malatrix's Shard
+	8990,  250000,			-- Largantua's Shard
+	8977,  250000,			-- Ironhorn Baldurno's Horn
+	8981,  250000,			-- Abyssdiver's Feather
+	8976,  250000,			-- Prickly Pitriv's Thread
+	8988,  250000,			-- Waraxe Beak's Hide
+	8982,  250000,			-- Intuila's Hide
+	8983,  250000,			-- Emperor Arthro's Shell
+	8707,  500000,			-- Raaz Hide
+	8709,  500000, 			-- Raaz Tusk
+	2169,  1000000,			-- Cerberus Hide
+	4027,  1000000,			-- Spool of Akaso Thread
+	722,   1000000,			-- Divine Log
+	8725,  1000000,			-- Exalted Log
+	702,   1000000,			-- Ebony Log
+	4018,  1000000,			-- Guatambu Log
+	8747,  1000000,			-- Chuck of Ra'Kaznar Ore
+	8723,  1000000,			-- Chunk of Beryllium Ore
+	4058,  1000000,			-- Chunk of Bismuth Ore
+	3922,  1000000,			-- Chunk of Rhodium Ore
+	9075,  3000000,			-- Chunk of Vulcanite Ore
+	747,   2000000,			-- Orichalcum Ingot
+	2275,  2000000,			-- Scintillant Ingot
+	8724,  2000000,			-- Beryllium Ingot
+	8748,  2000000,			-- Ra'Kaznar Ingot
+	3923,  2000000,			-- Rhodium Ingot
+	8704,  2000000,			-- Bismuth Ingot
+	657,   2000000,			-- Lump of Tama-Hagane
+	8751,  2000000,			-- Square of Ancestral Cloth
+	836,   2000000,			-- Square of Damascene Cloth
+	4028,  2000000,			-- Square of Akaso Cloth
+	723,   2000000,			-- Piece of Divine Lumber
+	8726,  2000000,			-- Piece of Exalted Lumber
+	719,   2000000,			-- Piece of Ebony Lumber
+	4019,  2000000,			-- Piece of Guatambu Lumber
+	21392, 5000000,			-- Animator Z
+	21393, 5000000,			-- Arasy Sachet
+}
+	
+local stock_t2_locked = {
+	9249, 1500000,			-- Chunk of Ruthenium Ore
+	9247, 1500000,			-- Chunk of Niobium Ore
+	8721, 1500000,			-- Chunk of Hepatizon Ore
+	9251, 1500000,			-- Spool of Khoma Thread
+	1313, 2500000,			-- Locks of Siren's hair
+	8727, 2500000,			-- Sif's Lock
+	3449, 2500000,			-- Celaeno's Cloth
+	3544, 2500000,			-- Penelope's Cloth
+	3549, 500000,			-- Vial of Belladonna sap
+	3926, 4000000,			-- Urunday Log
+	9245, 4000000,			-- Cypress Log
+	3547, 5000000,			-- Sealord Skin
+	4080, 5000000,			-- Moonbow Urushi
+	4081, 5000000,			-- Moonbow Stone
+	4077, 5000000,			-- Piece of Moonbow Steel
+	4079, 5000000,			-- Square of Moonbow Leather
+	4078, 5000000,			-- Bolt of Moonbow Cloth
+	9252, 5000000,			-- Square of Khoma Cloth
+	8720, 5000000,			-- Maliyakaleya Orb
+	9250, 7500000,			-- Ruthenium Ingot
+	9248, 7500000,			-- Niobium Ingot
+	8722, 7500000,			-- Hepatizon Ingot
+	3927, 7500000,			-- Piece of Urunday Lumber
+	9246, 7500000,			-- Piece of Cypress Lumber
+	2359, 7500000,			-- Star Sapphire
+	1409, 7500000, 			-- Spool of Siren's Macrame
+	8728, 7500000,			-- Spool of Sif's Macrame
+	4014, 7500000,			-- Yggdreant Bole
+	766,  10000000,			-- Ormolu Ingot
+	8719, 10000000,			-- Piece of Maliyakaleya Coral
+	9062, 10000000,			-- Dark Matter
+	9003, 15000000,			-- Chunk of Plovid Flesh
+	3548, 15000000,			-- Square of Sealord Leather
+	9004, 15000000,			-- Macuil Plating
+	9006, 15000000,			-- Defiant Scarf
+	9061, 15000000,			-- Hades' Claw
+	9063, 15000000,			-- Tartarian Soul
+}
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	player:PrintToPlayer(string.format("History : I will provide rewards for particular pieces of historical furniture you find on notorious monsters!"),xi.msg.channel.NS_SAY)
+	player:PrintToPlayer(string.format("History : I also sell advanced materials to proven heroes!"),xi.msg.channel.NS_SAY)
+end)
+
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrade",  npcToReplaceName), function(player, npc, trade)
+	local playerLvl = player:getMainLvl() + player:getItemLevel()
+	local t1Unlock = 0
+	local t2Unlock = 0
+	local valueTotal = 0
+	local tradeQty = {}
+	
+	-- Check for furnishings included in trade
+	for i = 1, #acceptedTrades do
+		if (npcUtil.tradeHas(trade, {acceptedTrades[i][1]})) then
+			tradeQty[i] = trade:getItemQty(acceptedTrades[i][1])
+			valueTotal = valueTotal + (tradeQty[i] * acceptedTrades[i][2])
+			-- printf("History.lua onTrade  TRADE %i QTY: [%i]  TOTAL VALUE: [%i]", i, tradeQty[i], valueTotal)
+		end
+	end
+		
+	if (valueTotal > 0 and trade:getGil() == 0) then
+		player:PrintToPlayer(string.format("History : Here's %i gil for your valuable finds!", valueTotal),xi.msg.channel.NS_SAY)
+		player:tradeComplete()
+		player:addGil(valueTotal)
+	elseif (valueTotal == 0 and trade:getGil() == 0) then
+		player:PrintToPlayer(string.format("History : Sorry, I can't take those items.", valueTotal),xi.msg.channel.NS_SAY)
+	end
+	
+	-- Shops
+	if (valueTotal == 0 and trade:getGil() > 0) then
+		if (player:getCharVar("KillCounter_AbsoluteVirtue") >= 1) then
+			t1Unlock = 1
+		end
+		
+		if (player:getCharVar("KillCounter_Akvan") >= 1 and player:getCharVar("KillCounter_Kaggen") >= 1 and player:getCharVar("KillCounter_Pil") >= 1) then
+			t2Unlock = 1
+		end
+		
+		if (trade:getGil() == 2 and t1Unlock == 1 and t2Unlock == 1) then
+			player:PrintToPlayer(string.format("History : I sell advanced materials to proven heroes! Here's the second page of my shop!"),xi.msg.channel.NS_SAY)
+			xi.shop.general(player, stock_t2_locked)
+		elseif (trade:getGil() == 1 and t1Unlock == 1) then
+			player:PrintToPlayer(string.format("History : I sell advanced materials to proven heroes! Here's the first page of my shop!"),xi.msg.channel.NS_SAY)
+			xi.shop.general(player, stock_t1_locked)
+		else
+			player:PrintToPlayer(string.format("History : Looks like there's still some killing to be done before I can sell anything to you."),xi.msg.channel.NS_SAY)
+		end
+	end
+end)
+
+return m 

--- a/modules/custom/lua/caldera_npc_module/Institutions.lua
+++ b/modules/custom/lua/caldera_npc_module/Institutions.lua
@@ -54,54 +54,54 @@ local ValidSpells =
 -- Corsair Rolls
 local ValidRolls = {
     98, -- Fighter's Roll
-	99, -- Monk's Roll
-	100, -- Healer's Roll
-	101, -- Wizard's Roll
-	102, -- Warlock's Roll
-	103, -- Rogue's Roll
-	104, -- Gallant's Roll
-	105, -- Chaos Roll
-	106, -- Beast Roll
-	107, -- Choral Roll
-	108, -- Hunter's Roll
-	109, -- Samurai Roll
-	110, -- Ninja Roll
-	111, -- Drachen Roll
-	112, -- Evoker's Roll
-	113, -- Magus' Roll
-	114, -- Corsair's Roll
-	115, -- Puppet's Roll
-	116, -- Dancer's Roll
-	117, -- Scholar's Roll
-	118, -- Bolter's Roll
-	119, -- Caster's Roll
-	120, -- Courser's Roll
-	121, -- Blitzer's Roll
-	122, -- Tactician's Roll
-	302, -- Allies Roll
-	303, -- Miser's Roll
-	304, -- Companion's Roll
-	305, -- Avenger's Roll
-	390, -- Naturalist's Roll
-	391, -- Runeist's Roll
+    99, -- Monk's Roll
+    100, -- Healer's Roll
+    101, -- Wizard's Roll
+    102, -- Warlock's Roll
+    103, -- Rogue's Roll
+    104, -- Gallant's Roll
+    105, -- Chaos Roll
+    106, -- Beast Roll
+    107, -- Choral Roll
+    108, -- Hunter's Roll
+    109, -- Samurai Roll
+    110, -- Ninja Roll
+    111, -- Drachen Roll
+    112, -- Evoker's Roll
+    113, -- Magus' Roll
+    114, -- Corsair's Roll
+    115, -- Puppet's Roll
+    116, -- Dancer's Roll
+    117, -- Scholar's Roll
+    118, -- Bolter's Roll
+    119, -- Caster's Roll
+    120, -- Courser's Roll
+    121, -- Blitzer's Roll
+    122, -- Tactician's Roll
+    302, -- Allies Roll
+    303, -- Miser's Roll
+    304, -- Companion's Roll
+    305, -- Avenger's Roll
+    390, -- Naturalist's Roll
+    391, -- Runeist's Roll
 }
 
 -- Automaton Attachments
 local ValidAttachments = {
-	8193, 8194, 8195, 8196, 8197, 8198, 8224, 8225, 8226, 8227,
-	8449, 8450, 8451, 8452, 8453, 8454, 8455, 8456, 8458,
-	8462, 8481, 8482, 8483, 8484, 8485, 8486, 8487, 8488, 8489, 8490, 8491, 8493, 8497,
-	8513, 8514, 8515, 8516, 8517, 8518, 8519, 8520,
-	8523, 8524, 8526, 8528, 8545, 8546, 8547, 8548, 8549, 8550, 8551,
-	8555, 8577, 8578, 8579, 8580, 8581, 8582, 8583, 8584, 8585,
-	8587, 8609, 8610, 8611, 8612, 8613, 8614, 8615, 8616,
-	8619, 8641, 8642, 8643, 8644, 8645, 8646, 8648, 8651,
-	8673, 8674, 8675, 8676, 8677, 8678, 8680, 8682, 9138, 9143, 9230,
+    8193, 8194, 8195, 8196, 8197, 8198, 8224, 8225, 8226, 8227,
+    8449, 8450, 8451, 8452, 8453, 8454, 8455, 8456, 8458,
+    8462, 8481, 8482, 8483, 8484, 8485, 8486, 8487, 8488, 8489, 8490, 8491, 8493, 8497,
+    8513, 8514, 8515, 8516, 8517, 8518, 8519, 8520,
+    8523, 8524, 8526, 8528, 8545, 8546, 8547, 8548, 8549, 8550, 8551,
+    8555, 8577, 8578, 8579, 8580, 8581, 8582, 8583, 8584, 8585,
+    8587, 8609, 8610, 8611, 8612, 8613, 8614, 8615, 8616,
+    8619, 8641, 8642, 8643, 8644, 8645, 8646, 8648, 8651,
+    8673, 8674, 8675, 8676, 8677, 8678, 8680, 8682, 9138, 9143, 9230,
 }
 
 local ValidTrusts = {
-	896, 898, 899, 900, 901, 902, 903, 904, 905, 908, 909, 910, 911, 913, 917, 933,
-	940, 951, 952, 968, 1010, 1019
+    896, 898, 899, 900, 901, 902, 903, 904, 905, 908, 909, 910, 911, 913, 917, 933,
+    940, 951, 952, 968, 1010, 1019
 }
 
 local function AddAllSpells(player)
@@ -123,113 +123,113 @@ local function AddAllAttachments(player)
 end
 
 local function AddAllMounts(player)
-	for i = xi.ki.CHOCOBO_COMPANION, xi.ki.CHOCOBO_COMPANION + 26 do
+    for i = xi.ki.CHOCOBO_COMPANION, xi.ki.CHOCOBO_COMPANION + 26 do
         player:addKeyItem(i)
     end
 end
 
 local function AddAllChairs(player)
-	for i = xi.ki.IMPERIAL_CHAIR, xi.ki.LEAF_BENCH do
+    for i = xi.ki.IMPERIAL_CHAIR, xi.ki.LEAF_BENCH do
         player:addKeyItem(i)
     end
 end
 
 local function AddAllTrusts(player)
-	for i = 1, #ValidTrusts do
-		player:addSpell(ValidTrusts[i], true, true)
-	end
+    for i = 1, #ValidTrusts do
+        player:addSpell(ValidTrusts[i], true, true)
+    end
 end
 
 local function SetZilart(player)
-	local missionZM = {0, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 23, 24, 26, 27, 28, 30}
+    local missionZM = {0, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 23, 24, 26, 27, 28, 30}
 
-	for i = 1, #missionZM do
---		player:completeMission(3, 0)
---		player:delMission(3, missionZM[i])
-		player:completeMission(3, missionZM[i])
-		player:addMission(3, missionZM[i] + 1)
-	end
-	
-	player:addMission(3, 31) -- RoZ: Awakening
-	player:addKeyItem(238) -- Sacrifical Chamber Key
-	player:addKeyItem(247) -- Prismatic Fragment
-	player:addKeyItem(452) -- Cerulean Crystal
+    for i = 1, #missionZM do
+--      player:completeMission(3, 0)
+--      player:delMission(3, missionZM[i])
+        player:completeMission(3, missionZM[i])
+        player:addMission(3, missionZM[i] + 1)
+    end
+    
+    player:addMission(3, 31) -- RoZ: Awakening
+    player:addKeyItem(238) -- Sacrifical Chamber Key
+    player:addKeyItem(247) -- Prismatic Fragment
+    player:addKeyItem(452) -- Cerulean Crystal
 end
 
 local function SetCoP(player)
-	local missionCoP = {101, 110, 118, 128, 138, 218, 228, 238, 248, 257, 258, 318, 325, 335, 341, 350, 358, 368, 418, 428, 438, 448,
-	                    518, 530, 543, 552, 560, 568, 578, 618, 628, 638, 648, 718, 728, 738, 748, 758, 800, 818, 828, 840, 850}
-						
-	for i = 1, #missionCoP do
-		player:addMission(3, missionCoP[i])
-		player:completeMission(3, missionCoP[i])
-	end
+    local missionCoP = {101, 110, 118, 128, 138, 218, 228, 238, 248, 257, 258, 318, 325, 335, 341, 350, 358, 368, 418, 428, 438, 448,
+                        518, 530, 543, 552, 560, 568, 578, 618, 628, 638, 648, 718, 728, 738, 748, 758, 800, 818, 828, 840, 850}
+                        
+    for i = 1, #missionCoP do
+        player:addMission(3, missionCoP[i])
+        player:completeMission(3, missionCoP[i])
+    end
 
-	player:addMission(6, 850) -- CoP: The Last Verse
-	player:addKeyItem(708) -- Mysterious Amulet
-	player:addKeyItem(591) -- Light of Dem
-	player:addKeyItem(590) -- Light of Holla
-	player:addKeyItem(592) -- Light of Mea
-	player:addKeyItem(604) -- Pso'Xja Pass
-	player:addKeyItem(593) -- Light of Vahzl
-	player:addKeyItem(594) -- Light of Al'Taieu
-	player:addItem(14657) -- Ducal Guard's Ring
-	player:addItem(14672) -- Tavnazian Ring
+    player:addMission(6, 850) -- CoP: The Last Verse
+    player:addKeyItem(708) -- Mysterious Amulet
+    player:addKeyItem(591) -- Light of Dem
+    player:addKeyItem(590) -- Light of Holla
+    player:addKeyItem(592) -- Light of Mea
+    player:addKeyItem(604) -- Pso'Xja Pass
+    player:addKeyItem(593) -- Light of Vahzl
+    player:addKeyItem(594) -- Light of Al'Taieu
+    player:addItem(14657) -- Ducal Guard's Ring
+    player:addItem(14672) -- Tavnazian Ring
 end
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	if (player:getCharVar("HasTriggeredInstitutions") == 0) then
-		player:PrintToPlayer(string.format("Institutions : Please wait. This will take a moment."),xi.msg.channel.NS_SAY)
-		player:unlockJob(0)
-		player:unlockJob(xi.job.DRG)
-		player:setPetName(xi.pet.type.WYVERN, math.random(1,32))
-		player:unlockJob(xi.job.PUP)
-		player:setPetName(xi.pet.type.AUTOMATON, math.random(118, 149))
-		player:capAllSkills()
-		AddAllSpells(player)
-		AddAllRolls(player)
-		AddAllAttachments(player)
-		AddAllMounts(player)
-		AddAllChairs(player)
-		AddAllTrusts(player)
-		SetZilart(player)
-		SetCoP(player)
-		player:PrintToPlayer(string.format("Institutions : Capped all combat/magic skills. Added all spells/songs, COR rolls, and PUP starter attachments. Unlocked all mounts and chairs."),xi.msg.channel.NS_SAY)
-		player:PrintToPlayer(string.format("Institutions : DRG and PUP pet names have been randomized. Visit Fouvia (DRG) or Abda-Lurabda (PUP) to change them."),xi.msg.channel.NS_SAY)
-		player:PrintToPlayer(string.format("Institutions : All Rise of the Zilart and Chains of Promathia missions completed."),xi.msg.channel.NS_SAY)
-		player:PrintToPlayer(string.format("Institutions : Please zone for all changes to display properly."),xi.msg.channel.NS_SAY)
-		player:setCharVar("HasTriggeredInstitutions", 1)
-		player:setCharVar("HasTriggeredRoZCoP", 1)
-	else
-		-- if (player:getCharVar("HasTriggeredRoZCoP") == 0) then
-			-- SetZilart(player)
-			-- SetCoP(player)
-			-- player:setCharVar("HasTriggeredRoZCoP", 1)
-		-- end
---		AddAllAttachments(player)
-		player:PrintToPlayer(string.format("Institutions : Looks like you've already had everything unlocked! Visit Fouvia (DRG) or Abda-Lurabda (PUP) to change your pet's name."),xi.msg.channel.NS_SAY)
-		player:PrintToPlayer(string.format("Institutions : You can trade me EXP rings to have them refilled in exchange for conquest points!"),xi.msg.channel.NS_SAY)
-	end
+    if (player:getCharVar("HasTriggeredInstitutions") == 0) then
+        player:PrintToPlayer(string.format("Institutions : Please wait. This will take a moment."),xi.msg.channel.NS_SAY)
+        player:unlockJob(0)
+        player:unlockJob(xi.job.DRG)
+        player:setPetName(xi.pet.type.WYVERN, math.random(1,32))
+        player:unlockJob(xi.job.PUP)
+        player:setPetName(xi.pet.type.AUTOMATON, math.random(118, 149))
+        player:capAllSkills()
+        AddAllSpells(player)
+        AddAllRolls(player)
+        AddAllAttachments(player)
+        AddAllMounts(player)
+        AddAllChairs(player)
+        AddAllTrusts(player)
+        SetZilart(player)
+        SetCoP(player)
+        player:PrintToPlayer(string.format("Institutions : Capped all combat/magic skills. Added all spells/songs, COR rolls, and PUP starter attachments. Unlocked all mounts and chairs."),xi.msg.channel.NS_SAY)
+        player:PrintToPlayer(string.format("Institutions : DRG and PUP pet names have been randomized. Visit Fouvia (DRG) or Abda-Lurabda (PUP) to change them."),xi.msg.channel.NS_SAY)
+        player:PrintToPlayer(string.format("Institutions : All Rise of the Zilart and Chains of Promathia missions completed."),xi.msg.channel.NS_SAY)
+        player:PrintToPlayer(string.format("Institutions : Please zone for all changes to display properly."),xi.msg.channel.NS_SAY)
+        player:setCharVar("HasTriggeredInstitutions", 1)
+        player:setCharVar("HasTriggeredRoZCoP", 1)
+    else
+        -- if (player:getCharVar("HasTriggeredRoZCoP") == 0) then
+            -- SetZilart(player)
+            -- SetCoP(player)
+            -- player:setCharVar("HasTriggeredRoZCoP", 1)
+        -- end
+--      AddAllAttachments(player)
+        player:PrintToPlayer(string.format("Institutions : Looks like you've already had everything unlocked! Visit Fouvia (DRG) or Abda-Lurabda (PUP) to change your pet's name."),xi.msg.channel.NS_SAY)
+        player:PrintToPlayer(string.format("Institutions : You can trade me EXP rings to have them refilled in exchange for conquest points!"),xi.msg.channel.NS_SAY)
+    end
 end)
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrade", npcToReplaceName), function(player, npc, trade)
-	local ringID = {10796, 11666, 14671, 15761, 15762, 15763, 15793, 15840, 26164, 27556, 28528, 28562, 28568, 28569}
-	local ringCPCost = {500, 450, 1500, 500, 750, 1500, 500, 1500, 1500, 1500, 600, 650, 1500, 1500}
+    local ringID = {10796, 11666, 14671, 15761, 15762, 15763, 15793, 15840, 26164, 27556, 28528, 28562, 28568, 28569}
+    local ringCPCost = {500, 450, 1500, 500, 750, 1500, 500, 1500, 1500, 1500, 600, 650, 1500, 1500}
 
-	local itemToReplenish = 0
-	local itemFound = false
-	local currentCP = player:getCP()
-	
-	for i = 1, 14 do
-		if (trade:hasItemQty(ringID[i], 1) and currentCP >= ringCPCost[i]) then
-			player:tradeComplete()
-			
-			player:delCP(ringCPCost[i])
-			player:addItem(ringID[i], 1)
-			player:PrintToPlayer(string.format("You exchanged %i Conquest Points to recharge your ring.", ringCPCost[i]),xi.msg.channel.SYSTEM_3)
-			player:messageSpecial(ID.text.ITEM_OBTAINED, ringID[i])
-		end
-	end
+    local itemToReplenish = 0
+    local itemFound = false
+    local currentCP = player:getCP()
+    
+    for i = 1, 14 do
+        if (trade:hasItemQty(ringID[i], 1) and currentCP >= ringCPCost[i]) then
+            player:tradeComplete()
+            
+            player:delCP(ringCPCost[i])
+            player:addItem(ringID[i], 1)
+            player:PrintToPlayer(string.format("You exchanged %i Conquest Points to recharge your ring.", ringCPCost[i]),xi.msg.channel.SYSTEM_3)
+            player:messageSpecial(ID.text.ITEM_OBTAINED, ringID[i])
+        end
+    end
 end)
 
 return m 

--- a/modules/custom/lua/caldera_npc_module/Institutions.lua
+++ b/modules/custom/lua/caldera_npc_module/Institutions.lua
@@ -1,0 +1,235 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Institutions
+-- !pos -94.6732 -2.1500 -99.3882 6 284
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
+require("scripts/globals/missions")
+require("modules/module_utils")
+-----------------------------------
+local m = Module:new("Institutions")
+
+local npcToReplaceName = "Institutions"
+
+-- All white, black, blue spells and BRD songs
+local ValidSpells =
+{
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 33, 35, 36, 37,
+    38, 39, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
+    72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104,
+    105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130,
+    131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156,
+    157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182,
+    183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208,
+    209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234,
+    235, 236, 237, 238, 239, 240, 241, 242, 243, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 258, 259, 260,
+    261, 262, 263, 264, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286,
+    287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312,
+    313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338,
+    339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355,
+    367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390,
+    391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416,
+    418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, -- 417: Honor March
+    443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468,
+    469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494,
+    495, 496, 497, 498, 499, 500, 501, 502, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 515, 517, 519, 521, 522, 524, 527,
+    529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 547, 548, 549, 551, 554, 555, 557, 560, 561,
+    563, 564, 565, 567, 569, 570, 572, 573, 574, 575, 576, 577, 578, 579, 581, 582, 584, 585, 587, 588, 589, 591, 592, 593, 594, 595,
+    596, 597, 598, 599, 603, 604, 605, 606, 608, 610, 611, 612, 613, 614, 615, 616, 617, 618, 620, 621, 622, 623, 626, 628, 629, 631,
+    632, 633, 634, 636, 637, 638, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657, 658, 659,
+    660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679, 680, 681, 682, 683, 684, 685,
+    686, 687, 688, 689, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700, 701, 702, 703, 704, 705, 706, 707, 708, 709, 710, 711,
+    712, 713, 714, 715, 716, 717, 718, 719, 720, 721, 722, 723, 724, 725, 726, 727, 728, 736, 737, 738, 739, 740, 741, 742, 743, 744,
+    745, 746, 747, 748, 749, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788,
+    789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 801, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814,
+    815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840,
+    841, 842, 843, 844, 845, 846, 848, 849, 850, 851, 852, 853, 854, 855, 856, 857, 858, 859, 860, 861, 862, 863, 864, 865, 866, -- 847: Atomos
+    867, 868, 869, 870, 871, 872, 873, 874, 875, 876, 877, 878, 879, 880, 881, 882, 883, 884, 885, 886, 887, 888, 889, 890, 891, 892,
+    893, 894, 895
+}
+
+-- Corsair Rolls
+local ValidRolls = {
+    98, -- Fighter's Roll
+	99, -- Monk's Roll
+	100, -- Healer's Roll
+	101, -- Wizard's Roll
+	102, -- Warlock's Roll
+	103, -- Rogue's Roll
+	104, -- Gallant's Roll
+	105, -- Chaos Roll
+	106, -- Beast Roll
+	107, -- Choral Roll
+	108, -- Hunter's Roll
+	109, -- Samurai Roll
+	110, -- Ninja Roll
+	111, -- Drachen Roll
+	112, -- Evoker's Roll
+	113, -- Magus' Roll
+	114, -- Corsair's Roll
+	115, -- Puppet's Roll
+	116, -- Dancer's Roll
+	117, -- Scholar's Roll
+	118, -- Bolter's Roll
+	119, -- Caster's Roll
+	120, -- Courser's Roll
+	121, -- Blitzer's Roll
+	122, -- Tactician's Roll
+	302, -- Allies Roll
+	303, -- Miser's Roll
+	304, -- Companion's Roll
+	305, -- Avenger's Roll
+	390, -- Naturalist's Roll
+	391, -- Runeist's Roll
+}
+
+-- Automaton Attachments
+local ValidAttachments = {
+	8193, 8194, 8195, 8196, 8197, 8198, 8224, 8225, 8226, 8227,
+	8449, 8450, 8451, 8452, 8453, 8454, 8455, 8456, 8458,
+	8462, 8481, 8482, 8483, 8484, 8485, 8486, 8487, 8488, 8489, 8490, 8491, 8493, 8497,
+	8513, 8514, 8515, 8516, 8517, 8518, 8519, 8520,
+	8523, 8524, 8526, 8528, 8545, 8546, 8547, 8548, 8549, 8550, 8551,
+	8555, 8577, 8578, 8579, 8580, 8581, 8582, 8583, 8584, 8585,
+	8587, 8609, 8610, 8611, 8612, 8613, 8614, 8615, 8616,
+	8619, 8641, 8642, 8643, 8644, 8645, 8646, 8648, 8651,
+	8673, 8674, 8675, 8676, 8677, 8678, 8680, 8682, 9138, 9143, 9230,
+}
+
+local ValidTrusts = {
+	896, 898, 899, 900, 901, 902, 903, 904, 905, 908, 909, 910, 911, 913, 917, 933,
+	940, 951, 952, 968, 1010, 1019
+}
+
+local function AddAllSpells(player)
+    for i = 1, #ValidSpells do
+        player:addSpell(ValidSpells[i], true, true) -- Spell ID, Silent, Save
+    end
+end
+
+local function AddAllRolls(player)
+    for i = 1, #ValidRolls do
+        player:addLearnedAbility(ValidRolls[i], true, true) -- Ability ID, Silent, Save
+    end
+end
+
+local function AddAllAttachments(player)
+    for i = 1, #ValidAttachments do
+        player:unlockAttachment(ValidAttachments[i])
+    end
+end
+
+local function AddAllMounts(player)
+	for i = xi.ki.CHOCOBO_COMPANION, xi.ki.CHOCOBO_COMPANION + 26 do
+        player:addKeyItem(i)
+    end
+end
+
+local function AddAllChairs(player)
+	for i = xi.ki.IMPERIAL_CHAIR, xi.ki.LEAF_BENCH do
+        player:addKeyItem(i)
+    end
+end
+
+local function AddAllTrusts(player)
+	for i = 1, #ValidTrusts do
+		player:addSpell(ValidTrusts[i], true, true)
+	end
+end
+
+local function SetZilart(player)
+	local missionZM = {0, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 23, 24, 26, 27, 28, 30}
+
+	for i = 1, #missionZM do
+--		player:completeMission(3, 0)
+--		player:delMission(3, missionZM[i])
+		player:completeMission(3, missionZM[i])
+		player:addMission(3, missionZM[i] + 1)
+	end
+	
+	player:addMission(3, 31) -- RoZ: Awakening
+	player:addKeyItem(238) -- Sacrifical Chamber Key
+	player:addKeyItem(247) -- Prismatic Fragment
+	player:addKeyItem(452) -- Cerulean Crystal
+end
+
+local function SetCoP(player)
+	local missionCoP = {101, 110, 118, 128, 138, 218, 228, 238, 248, 257, 258, 318, 325, 335, 341, 350, 358, 368, 418, 428, 438, 448,
+	                    518, 530, 543, 552, 560, 568, 578, 618, 628, 638, 648, 718, 728, 738, 748, 758, 800, 818, 828, 840, 850}
+						
+	for i = 1, #missionCoP do
+		player:addMission(3, missionCoP[i])
+		player:completeMission(3, missionCoP[i])
+	end
+
+	player:addMission(6, 850) -- CoP: The Last Verse
+	player:addKeyItem(708) -- Mysterious Amulet
+	player:addKeyItem(591) -- Light of Dem
+	player:addKeyItem(590) -- Light of Holla
+	player:addKeyItem(592) -- Light of Mea
+	player:addKeyItem(604) -- Pso'Xja Pass
+	player:addKeyItem(593) -- Light of Vahzl
+	player:addKeyItem(594) -- Light of Al'Taieu
+	player:addItem(14657) -- Ducal Guard's Ring
+	player:addItem(14672) -- Tavnazian Ring
+end
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	if (player:getCharVar("HasTriggeredInstitutions") == 0) then
+		player:PrintToPlayer(string.format("Institutions : Please wait. This will take a moment."),xi.msg.channel.NS_SAY)
+		player:unlockJob(0)
+		player:unlockJob(xi.job.DRG)
+		player:setPetName(xi.pet.type.WYVERN, math.random(1,32))
+		player:unlockJob(xi.job.PUP)
+		player:setPetName(xi.pet.type.AUTOMATON, math.random(118, 149))
+		player:capAllSkills()
+		AddAllSpells(player)
+		AddAllRolls(player)
+		AddAllAttachments(player)
+		AddAllMounts(player)
+		AddAllChairs(player)
+		AddAllTrusts(player)
+		SetZilart(player)
+		SetCoP(player)
+		player:PrintToPlayer(string.format("Institutions : Capped all combat/magic skills. Added all spells/songs, COR rolls, and PUP starter attachments. Unlocked all mounts and chairs."),xi.msg.channel.NS_SAY)
+		player:PrintToPlayer(string.format("Institutions : DRG and PUP pet names have been randomized. Visit Fouvia (DRG) or Abda-Lurabda (PUP) to change them."),xi.msg.channel.NS_SAY)
+		player:PrintToPlayer(string.format("Institutions : All Rise of the Zilart and Chains of Promathia missions completed."),xi.msg.channel.NS_SAY)
+		player:PrintToPlayer(string.format("Institutions : Please zone for all changes to display properly."),xi.msg.channel.NS_SAY)
+		player:setCharVar("HasTriggeredInstitutions", 1)
+		player:setCharVar("HasTriggeredRoZCoP", 1)
+	else
+		-- if (player:getCharVar("HasTriggeredRoZCoP") == 0) then
+			-- SetZilart(player)
+			-- SetCoP(player)
+			-- player:setCharVar("HasTriggeredRoZCoP", 1)
+		-- end
+--		AddAllAttachments(player)
+		player:PrintToPlayer(string.format("Institutions : Looks like you've already had everything unlocked! Visit Fouvia (DRG) or Abda-Lurabda (PUP) to change your pet's name."),xi.msg.channel.NS_SAY)
+		player:PrintToPlayer(string.format("Institutions : You can trade me EXP rings to have them refilled in exchange for conquest points!"),xi.msg.channel.NS_SAY)
+	end
+end)
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrade", npcToReplaceName), function(player, npc, trade)
+	local ringID = {10796, 11666, 14671, 15761, 15762, 15763, 15793, 15840, 26164, 27556, 28528, 28562, 28568, 28569}
+	local ringCPCost = {500, 450, 1500, 500, 750, 1500, 500, 1500, 1500, 1500, 600, 650, 1500, 1500}
+
+	local itemToReplenish = 0
+	local itemFound = false
+	local currentCP = player:getCP()
+	
+	for i = 1, 14 do
+		if (trade:hasItemQty(ringID[i], 1) and currentCP >= ringCPCost[i]) then
+			player:tradeComplete()
+			
+			player:delCP(ringCPCost[i])
+			player:addItem(ringID[i], 1)
+			player:PrintToPlayer(string.format("You exchanged %i Conquest Points to recharge your ring.", ringCPCost[i]),xi.msg.channel.SYSTEM_3)
+			player:messageSpecial(ID.text.ITEM_OBTAINED, ringID[i])
+		end
+	end
+end)
+
+return m 

--- a/modules/custom/lua/caldera_npc_module/Jedelaih.lua
+++ b/modules/custom/lua/caldera_npc_module/Jedelaih.lua
@@ -15,84 +15,84 @@ local m = Module:new("Jedelaih")
 local npcToReplaceName = "Jedelaih"
 
 local acceptedSeals = {
-					   -- Beastmen's Seal, Kindred's Crest, High Kindred Crest, Sacred Kindred Crest
-					   1126, 2955, 2956, 2957
-					   }
+                       -- Beastmen's Seal, Kindred's Crest, High Kindred Crest, Sacred Kindred Crest
+                       1126, 2955, 2956, 2957
+                       }
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrade", npcToReplaceName), function(player,npc,trade)
-	local sealID
-	local sealQty
-	local foundType
-	local resultingKSeals
-	
-	for i = 1, #acceptedSeals do
-		sealQty = trade:getItemQty(acceptedSeals[i])
-		
-		if (sealQty > 0) then
-			sealID = acceptedSeals[i]
-			foundType = i
-			break
-		end
-	end
-	
-	if (sealQty == 0 or sealQty == nil) then
-		player:PrintToPlayer(string.format("Jedelaih : What're ya tryin' to pull! I didn't ask for that!"),xi.msg.channel.NS_SAY)
-	elseif (foundType == 1 and sealQty % 3 == 0) then
-		resultingKSeals = sealQty / 3
-		
-		if (resultingKSeals > 1) then
-			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Beastmen's Seals and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
-		else
-			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Beastmen's Seals and give you %i Kindred's Seal.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
-		end
-	elseif (foundType == 2 and sealQty % 2 == 0) then
-		resultingKSeals = sealQty / 2
-		
-		if (resultingKSeals > 1) then
-			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Kindred's Crests and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
-		else
-			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Kindred's Crests and give you %i Kindred's Seal.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
-		end
-	elseif (foundType == 3) then
-		resultingKSeals = sealQty
-		
-		if (sealQty > 1) then
-			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i High Kindred's Crests and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
-		else
-			player:PrintToPlayer(string.format("Jedelaih : I'll take this %i High Kindred's Crest and give you %i Kindred's Seal.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
-		end
-	elseif (foundType == 4) then
-		resultingKSeals = sealQty * 2
-		
-		if (sealQty > 1) then
-			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Sacred Kindred's Crests and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
-		else
-			player:PrintToPlayer(string.format("Jedelaih : I'll take this %i Sacred Kindred's Crest and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
-		end
-	else
-		player:PrintToPlayer(string.format("Jedelaih : I'm gonna need more of those before I can convert them for you."),xi.msg.channel.NS_SAY)
-		return
-	end
-	
-	local trades = {{{sealID, sealQty}}}
-	
-	if npcUtil.tradeHasExactly(trade, trades[1]) then
-		player:addItem(1127, resultingKSeals)
-		player:messageSpecial(ID.text.ITEM_OBTAINED, 1127)
-		player:tradeComplete(trade)
-		player:PrintToPlayer(string.format("Jedelaih : Gahahaha! Much obliged! *madly strums away*."),xi.msg.channel.NS_SAY)
-	else
-		player:PrintToPlayer(string.format("Jedelaih : What're ya tryin' to pull! I didn't ask for that!"),xi.msg.channel.NS_SAY)
-		return
-	end
+    local sealID
+    local sealQty
+    local foundType
+    local resultingKSeals
+    
+    for i = 1, #acceptedSeals do
+        sealQty = trade:getItemQty(acceptedSeals[i])
+        
+        if (sealQty > 0) then
+            sealID = acceptedSeals[i]
+            foundType = i
+            break
+        end
+    end
+    
+    if (sealQty == 0 or sealQty == nil) then
+        player:PrintToPlayer(string.format("Jedelaih : What're ya tryin' to pull! I didn't ask for that!"),xi.msg.channel.NS_SAY)
+    elseif (foundType == 1 and sealQty % 3 == 0) then
+        resultingKSeals = sealQty / 3
+        
+        if (resultingKSeals > 1) then
+            player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Beastmen's Seals and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+        else
+            player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Beastmen's Seals and give you %i Kindred's Seal.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+        end
+    elseif (foundType == 2 and sealQty % 2 == 0) then
+        resultingKSeals = sealQty / 2
+        
+        if (resultingKSeals > 1) then
+            player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Kindred's Crests and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+        else
+            player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Kindred's Crests and give you %i Kindred's Seal.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+        end
+    elseif (foundType == 3) then
+        resultingKSeals = sealQty
+        
+        if (sealQty > 1) then
+            player:PrintToPlayer(string.format("Jedelaih : I'll take these %i High Kindred's Crests and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+        else
+            player:PrintToPlayer(string.format("Jedelaih : I'll take this %i High Kindred's Crest and give you %i Kindred's Seal.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+        end
+    elseif (foundType == 4) then
+        resultingKSeals = sealQty * 2
+        
+        if (sealQty > 1) then
+            player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Sacred Kindred's Crests and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+        else
+            player:PrintToPlayer(string.format("Jedelaih : I'll take this %i Sacred Kindred's Crest and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+        end
+    else
+        player:PrintToPlayer(string.format("Jedelaih : I'm gonna need more of those before I can convert them for you."),xi.msg.channel.NS_SAY)
+        return
+    end
+    
+    local trades = {{{sealID, sealQty}}}
+    
+    if npcUtil.tradeHasExactly(trade, trades[1]) then
+        player:addItem(1127, resultingKSeals)
+        player:messageSpecial(ID.text.ITEM_OBTAINED, 1127)
+        player:tradeComplete(trade)
+        player:PrintToPlayer(string.format("Jedelaih : Gahahaha! Much obliged! *madly strums away*."),xi.msg.channel.NS_SAY)
+    else
+        player:PrintToPlayer(string.format("Jedelaih : What're ya tryin' to pull! I didn't ask for that!"),xi.msg.channel.NS_SAY)
+        return
+    end
 end)
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	player:PrintToPlayer(string.format("Jedelaih : I'll convert Beastmen Seals, Kindred's Crests, High Kindred Crests, and Sacred Kindred Crests into Kindred's Seals!"),xi.msg.channel.NS_SAY)
-	player:PrintToPlayer(string.format("Jedelaih : My exchange rates are:"),xi.msg.channel.NS_SAY)
-	player:PrintToPlayer(string.format("Jedelaih : 3 Beastmen Seals -> 1 Kindred's Seal          2 Kindred's Crests -> 1 Kindred's Seal"),xi.msg.channel.NS_SAY)
-	player:PrintToPlayer(string.format("Jedelaih : 1 High Kindred's Crest -> 1 Kindred's Seal     1 Sacred Kindred's Crest -> 2 Kindred's Seals"),xi.msg.channel.NS_SAY)
-	-- player:PrintToPlayer(string.format("Jedelaih : Gahahaha! *madly strums away*"),xi.msg.channel.NS_SAY)
+    player:PrintToPlayer(string.format("Jedelaih : I'll convert Beastmen Seals, Kindred's Crests, High Kindred Crests, and Sacred Kindred Crests into Kindred's Seals!"),xi.msg.channel.NS_SAY)
+    player:PrintToPlayer(string.format("Jedelaih : My exchange rates are:"),xi.msg.channel.NS_SAY)
+    player:PrintToPlayer(string.format("Jedelaih : 3 Beastmen Seals -> 1 Kindred's Seal          2 Kindred's Crests -> 1 Kindred's Seal"),xi.msg.channel.NS_SAY)
+    player:PrintToPlayer(string.format("Jedelaih : 1 High Kindred's Crest -> 1 Kindred's Seal     1 Sacred Kindred's Crest -> 2 Kindred's Seals"),xi.msg.channel.NS_SAY)
+    -- player:PrintToPlayer(string.format("Jedelaih : Gahahaha! *madly strums away*"),xi.msg.channel.NS_SAY)
 end)
 
 return m 

--- a/modules/custom/lua/caldera_npc_module/Jedelaih.lua
+++ b/modules/custom/lua/caldera_npc_module/Jedelaih.lua
@@ -1,0 +1,98 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Jedelaih
+-- !pos -99 -2 -104 284
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/npc_util")
+require("scripts/globals/status")
+require("modules/module_utils")
+-----------------------------------
+
+local m = Module:new("Jedelaih")
+
+local npcToReplaceName = "Jedelaih"
+
+local acceptedSeals = {
+					   -- Beastmen's Seal, Kindred's Crest, High Kindred Crest, Sacred Kindred Crest
+					   1126, 2955, 2956, 2957
+					   }
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrade", npcToReplaceName), function(player,npc,trade)
+	local sealID
+	local sealQty
+	local foundType
+	local resultingKSeals
+	
+	for i = 1, #acceptedSeals do
+		sealQty = trade:getItemQty(acceptedSeals[i])
+		
+		if (sealQty > 0) then
+			sealID = acceptedSeals[i]
+			foundType = i
+			break
+		end
+	end
+	
+	if (sealQty == 0 or sealQty == nil) then
+		player:PrintToPlayer(string.format("Jedelaih : What're ya tryin' to pull! I didn't ask for that!"),xi.msg.channel.NS_SAY)
+	elseif (foundType == 1 and sealQty % 3 == 0) then
+		resultingKSeals = sealQty / 3
+		
+		if (resultingKSeals > 1) then
+			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Beastmen's Seals and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+		else
+			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Beastmen's Seals and give you %i Kindred's Seal.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+		end
+	elseif (foundType == 2 and sealQty % 2 == 0) then
+		resultingKSeals = sealQty / 2
+		
+		if (resultingKSeals > 1) then
+			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Kindred's Crests and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+		else
+			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Kindred's Crests and give you %i Kindred's Seal.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+		end
+	elseif (foundType == 3) then
+		resultingKSeals = sealQty
+		
+		if (sealQty > 1) then
+			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i High Kindred's Crests and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+		else
+			player:PrintToPlayer(string.format("Jedelaih : I'll take this %i High Kindred's Crest and give you %i Kindred's Seal.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+		end
+	elseif (foundType == 4) then
+		resultingKSeals = sealQty * 2
+		
+		if (sealQty > 1) then
+			player:PrintToPlayer(string.format("Jedelaih : I'll take these %i Sacred Kindred's Crests and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+		else
+			player:PrintToPlayer(string.format("Jedelaih : I'll take this %i Sacred Kindred's Crest and give you %i Kindred's Seals.", sealQty, resultingKSeals),xi.msg.channel.NS_SAY)
+		end
+	else
+		player:PrintToPlayer(string.format("Jedelaih : I'm gonna need more of those before I can convert them for you."),xi.msg.channel.NS_SAY)
+		return
+	end
+	
+	local trades = {{{sealID, sealQty}}}
+	
+	if npcUtil.tradeHasExactly(trade, trades[1]) then
+		player:addItem(1127, resultingKSeals)
+		player:messageSpecial(ID.text.ITEM_OBTAINED, 1127)
+		player:tradeComplete(trade)
+		player:PrintToPlayer(string.format("Jedelaih : Gahahaha! Much obliged! *madly strums away*."),xi.msg.channel.NS_SAY)
+	else
+		player:PrintToPlayer(string.format("Jedelaih : What're ya tryin' to pull! I didn't ask for that!"),xi.msg.channel.NS_SAY)
+		return
+	end
+end)
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	player:PrintToPlayer(string.format("Jedelaih : I'll convert Beastmen Seals, Kindred's Crests, High Kindred Crests, and Sacred Kindred Crests into Kindred's Seals!"),xi.msg.channel.NS_SAY)
+	player:PrintToPlayer(string.format("Jedelaih : My exchange rates are:"),xi.msg.channel.NS_SAY)
+	player:PrintToPlayer(string.format("Jedelaih : 3 Beastmen Seals -> 1 Kindred's Seal          2 Kindred's Crests -> 1 Kindred's Seal"),xi.msg.channel.NS_SAY)
+	player:PrintToPlayer(string.format("Jedelaih : 1 High Kindred's Crest -> 1 Kindred's Seal     1 Sacred Kindred's Crest -> 2 Kindred's Seals"),xi.msg.channel.NS_SAY)
+	-- player:PrintToPlayer(string.format("Jedelaih : Gahahaha! *madly strums away*"),xi.msg.channel.NS_SAY)
+end)
+
+return m 

--- a/modules/custom/lua/caldera_npc_module/Makel-Pakel.lua
+++ b/modules/custom/lua/caldera_npc_module/Makel-Pakel.lua
@@ -1,0 +1,82 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Makel-Pakel
+-- !pos -106 -2 -99 284
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
+require("modules/module_utils")
+-----------------------------------
+
+local m = Module:new("Makel-Pakel")
+
+local npcToReplaceName = "Makel-Pakel"
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	local stock_Grips = 
+	{
+		19043, 7500,	-- Tenax Strap
+		19044, 7500, 	-- Disciple Grip
+		19045, 10000,	-- Succubus Grip
+		19039, 20000,	-- Orca Strap
+		19024, 35000,	-- Sword Strap
+		19021, 35000,	-- Katana Strap
+		19022, 35000,	-- Axe Grip
+		19023, 35000,	-- Staff Strap
+		19025, 35000,	-- Pole Grip
+		19026, 35000,	-- Spear Strap
+		19027, 35000,	-- Claymore Grip
+		19028, 50000,	-- Magic Strap
+		19040, 50000,	-- Shark Strap
+		19031, 50000,	-- Fire Grip
+		19032, 50000,	-- Water Grip
+		19033, 50000,	-- Wind Grip
+		19034, 50000,	-- Ice Grip
+		19035, 50000,	-- Thunder Grip
+		19036, 50000,	-- Earth Grip
+		19037, 50000,	-- Light Grip
+		19038, 50000,	-- Dark Grip
+		19029, 75000,	-- Brave Grip
+		19030, 75000,	-- Wise Strap
+		19048, 75000,	-- Reign Grip
+		18801, 75000,	-- Danger Grip
+		18803, 75000,	-- Pax Grip
+		19052, 75000,	-- Divinus Grip
+		19053, 75000,	-- Curatio Grip
+		19054, 75000,	-- Fulcio Grip
+		19055, 75000,	-- Macero Grip
+		19056, 75000,	-- Elementa Grip
+		19057, 75000,	-- Caecus Grip
+		19058, 75000,	-- Vox Grip
+		19059, 75000,	-- Quire Grip
+	}
+	
+	xi.shop.general(player, stock_Grips)
+	
+	player:PrintToPlayer(string.format("Makel-Pakel : I hear you're looking for grips for two-handed weapons!"),xi.msg.channel.NS_SAY)
+	-- local trigger = math.random(1,6)
+	
+	-- if (trigger == 1) then
+-- --		player:PrintToPlayer(string.format("Makel-Pakel : *sniffle* G-g-go away! Some weird guy named Lmfaoo dresses up like a dancer and keeps assaulting me!"),xi.msg.channel.NS_SAY)
+		-- player:PrintToPlayer(string.format("Makel-Pakel : I'm in recovery!"),xi.msg.channel.NS_SAY)
+	-- elseif (trigger == 2) then
+-- --		player:PrintToPlayer(string.format("Makel-Pakel : *whimper* Lmfaoo only makes me call him daddy..."),xi.msg.channel.NS_SAY)
+		-- player:PrintToPlayer(string.format("Makel-Pakel : *glances around suspiciously*"),xi.msg.channel.NS_SAY)
+	-- elseif (trigger == 3) then
+-- --		player:PrintToPlayer(string.format("Makel-Pakel : No! Please!"),xi.msg.channel.NS_SAY)
+		-- player:PrintToPlayer(string.format("Makel-Pakel : You haven't seen someone named Lmfaoo lurking around have you?"),xi.msg.channel.NS_SAY)
+	-- elseif (trigger == 4) then
+-- --		player:PrintToPlayer(string.format("Makel-Pakel : W-w-where am I?"),xi.msg.channel.NS_SAY)
+		-- player:PrintToPlayer(string.format("Makel-Pakel : Gah! You scared me!"),xi.msg.channel.NS_SAY)
+	-- elseif (trigger == 5) then
+-- --		player:PrintToPlayer(string.format("Makel-Pakel : Who are you?!"),xi.msg.channel.NS_SAY)
+		-- player:PrintToPlayer(string.format("Makel-Pakel : You're not going to start dancing are you?"),xi.msg.channel.NS_SAY)
+	-- elseif (trigger == 6) then
+-- --		player:PrintToPlayer(string.format("Makel-Pakel : How did I get here?!"),xi.msg.channel.NS_SAY)
+		-- player:PrintToPlayer(string.format("Makel-Pakel : *heaves a sigh of relief*"),xi.msg.channel.NS_SAY)
+	-- end
+end)
+
+return m

--- a/modules/custom/lua/caldera_npc_module/Makel-Pakel.lua
+++ b/modules/custom/lua/caldera_npc_module/Makel-Pakel.lua
@@ -15,68 +15,68 @@ local m = Module:new("Makel-Pakel")
 local npcToReplaceName = "Makel-Pakel"
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	local stock_Grips = 
-	{
-		19043, 7500,	-- Tenax Strap
-		19044, 7500, 	-- Disciple Grip
-		19045, 10000,	-- Succubus Grip
-		19039, 20000,	-- Orca Strap
-		19024, 35000,	-- Sword Strap
-		19021, 35000,	-- Katana Strap
-		19022, 35000,	-- Axe Grip
-		19023, 35000,	-- Staff Strap
-		19025, 35000,	-- Pole Grip
-		19026, 35000,	-- Spear Strap
-		19027, 35000,	-- Claymore Grip
-		19028, 50000,	-- Magic Strap
-		19040, 50000,	-- Shark Strap
-		19031, 50000,	-- Fire Grip
-		19032, 50000,	-- Water Grip
-		19033, 50000,	-- Wind Grip
-		19034, 50000,	-- Ice Grip
-		19035, 50000,	-- Thunder Grip
-		19036, 50000,	-- Earth Grip
-		19037, 50000,	-- Light Grip
-		19038, 50000,	-- Dark Grip
-		19029, 75000,	-- Brave Grip
-		19030, 75000,	-- Wise Strap
-		19048, 75000,	-- Reign Grip
-		18801, 75000,	-- Danger Grip
-		18803, 75000,	-- Pax Grip
-		19052, 75000,	-- Divinus Grip
-		19053, 75000,	-- Curatio Grip
-		19054, 75000,	-- Fulcio Grip
-		19055, 75000,	-- Macero Grip
-		19056, 75000,	-- Elementa Grip
-		19057, 75000,	-- Caecus Grip
-		19058, 75000,	-- Vox Grip
-		19059, 75000,	-- Quire Grip
-	}
-	
-	xi.shop.general(player, stock_Grips)
-	
-	player:PrintToPlayer(string.format("Makel-Pakel : I hear you're looking for grips for two-handed weapons!"),xi.msg.channel.NS_SAY)
-	-- local trigger = math.random(1,6)
-	
-	-- if (trigger == 1) then
--- --		player:PrintToPlayer(string.format("Makel-Pakel : *sniffle* G-g-go away! Some weird guy named Lmfaoo dresses up like a dancer and keeps assaulting me!"),xi.msg.channel.NS_SAY)
-		-- player:PrintToPlayer(string.format("Makel-Pakel : I'm in recovery!"),xi.msg.channel.NS_SAY)
-	-- elseif (trigger == 2) then
--- --		player:PrintToPlayer(string.format("Makel-Pakel : *whimper* Lmfaoo only makes me call him daddy..."),xi.msg.channel.NS_SAY)
-		-- player:PrintToPlayer(string.format("Makel-Pakel : *glances around suspiciously*"),xi.msg.channel.NS_SAY)
-	-- elseif (trigger == 3) then
--- --		player:PrintToPlayer(string.format("Makel-Pakel : No! Please!"),xi.msg.channel.NS_SAY)
-		-- player:PrintToPlayer(string.format("Makel-Pakel : You haven't seen someone named Lmfaoo lurking around have you?"),xi.msg.channel.NS_SAY)
-	-- elseif (trigger == 4) then
--- --		player:PrintToPlayer(string.format("Makel-Pakel : W-w-where am I?"),xi.msg.channel.NS_SAY)
-		-- player:PrintToPlayer(string.format("Makel-Pakel : Gah! You scared me!"),xi.msg.channel.NS_SAY)
-	-- elseif (trigger == 5) then
--- --		player:PrintToPlayer(string.format("Makel-Pakel : Who are you?!"),xi.msg.channel.NS_SAY)
-		-- player:PrintToPlayer(string.format("Makel-Pakel : You're not going to start dancing are you?"),xi.msg.channel.NS_SAY)
-	-- elseif (trigger == 6) then
--- --		player:PrintToPlayer(string.format("Makel-Pakel : How did I get here?!"),xi.msg.channel.NS_SAY)
-		-- player:PrintToPlayer(string.format("Makel-Pakel : *heaves a sigh of relief*"),xi.msg.channel.NS_SAY)
-	-- end
+    local stock_Grips = 
+    {
+        19043, 7500,    -- Tenax Strap
+        19044, 7500,    -- Disciple Grip
+        19045, 10000,   -- Succubus Grip
+        19039, 20000,   -- Orca Strap
+        19024, 35000,   -- Sword Strap
+        19021, 35000,   -- Katana Strap
+        19022, 35000,   -- Axe Grip
+        19023, 35000,   -- Staff Strap
+        19025, 35000,   -- Pole Grip
+        19026, 35000,   -- Spear Strap
+        19027, 35000,   -- Claymore Grip
+        19028, 50000,   -- Magic Strap
+        19040, 50000,   -- Shark Strap
+        19031, 50000,   -- Fire Grip
+        19032, 50000,   -- Water Grip
+        19033, 50000,   -- Wind Grip
+        19034, 50000,   -- Ice Grip
+        19035, 50000,   -- Thunder Grip
+        19036, 50000,   -- Earth Grip
+        19037, 50000,   -- Light Grip
+        19038, 50000,   -- Dark Grip
+        19029, 75000,   -- Brave Grip
+        19030, 75000,   -- Wise Strap
+        19048, 75000,   -- Reign Grip
+        18801, 75000,   -- Danger Grip
+        18803, 75000,   -- Pax Grip
+        19052, 75000,   -- Divinus Grip
+        19053, 75000,   -- Curatio Grip
+        19054, 75000,   -- Fulcio Grip
+        19055, 75000,   -- Macero Grip
+        19056, 75000,   -- Elementa Grip
+        19057, 75000,   -- Caecus Grip
+        19058, 75000,   -- Vox Grip
+        19059, 75000,   -- Quire Grip
+    }
+    
+    xi.shop.general(player, stock_Grips)
+    
+    player:PrintToPlayer(string.format("Makel-Pakel : I hear you're looking for grips for two-handed weapons!"),xi.msg.channel.NS_SAY)
+    -- local trigger = math.random(1,6)
+    
+    -- if (trigger == 1) then
+-- --       player:PrintToPlayer(string.format("Makel-Pakel : *sniffle* G-g-go away! Some weird guy named Lmfaoo dresses up like a dancer and keeps assaulting me!"),xi.msg.channel.NS_SAY)
+        -- player:PrintToPlayer(string.format("Makel-Pakel : I'm in recovery!"),xi.msg.channel.NS_SAY)
+    -- elseif (trigger == 2) then
+-- --       player:PrintToPlayer(string.format("Makel-Pakel : *whimper* Lmfaoo only makes me call him daddy..."),xi.msg.channel.NS_SAY)
+        -- player:PrintToPlayer(string.format("Makel-Pakel : *glances around suspiciously*"),xi.msg.channel.NS_SAY)
+    -- elseif (trigger == 3) then
+-- --       player:PrintToPlayer(string.format("Makel-Pakel : No! Please!"),xi.msg.channel.NS_SAY)
+        -- player:PrintToPlayer(string.format("Makel-Pakel : You haven't seen someone named Lmfaoo lurking around have you?"),xi.msg.channel.NS_SAY)
+    -- elseif (trigger == 4) then
+-- --       player:PrintToPlayer(string.format("Makel-Pakel : W-w-where am I?"),xi.msg.channel.NS_SAY)
+        -- player:PrintToPlayer(string.format("Makel-Pakel : Gah! You scared me!"),xi.msg.channel.NS_SAY)
+    -- elseif (trigger == 5) then
+-- --       player:PrintToPlayer(string.format("Makel-Pakel : Who are you?!"),xi.msg.channel.NS_SAY)
+        -- player:PrintToPlayer(string.format("Makel-Pakel : You're not going to start dancing are you?"),xi.msg.channel.NS_SAY)
+    -- elseif (trigger == 6) then
+-- --       player:PrintToPlayer(string.format("Makel-Pakel : How did I get here?!"),xi.msg.channel.NS_SAY)
+        -- player:PrintToPlayer(string.format("Makel-Pakel : *heaves a sigh of relief*"),xi.msg.channel.NS_SAY)
+    -- end
 end)
 
 return m

--- a/modules/custom/lua/caldera_npc_module/Personages.lua
+++ b/modules/custom/lua/caldera_npc_module/Personages.lua
@@ -16,235 +16,234 @@ local m = Module:new("Personages")
 local npcToReplaceName = "Personages"
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrade", npcToReplaceName), function(player,npc,trade)
-	local af = {12511, 12638, 13961, 14089, 14214}
-	local afHQ = {15225, 14473, 14890, 15561, 15352}
+    local af = {12511, 12638, 13961, 14089, 14214}
+    local afHQ = {15225, 14473, 14890, 15561, 15352}
 
-	local artifactArmor = {
-		[  1] = {trade = {af[1], af[2], af[3], af[4], af[5], {"gil", 250000}}, reward = {afHQ[1], afHQ[2], afHQ[3], afHQ[4], afHQ[5]}}, -- WAR
-		[  2] = {trade = {af[1] + 1, af[2] + 1, af[3] + 1, af[4] + 1, af[5] + 1, {"gil", 250000}}, reward = {afHQ[1] + 1, afHQ[2] + 1, afHQ[3] + 1, afHQ[4] + 1, afHQ[5] + 1}}, -- MNK
-		[  3] = {trade = {af[1] + 1344, af[2] + 2, af[3] + 2, af[4] + 2, af[5] + 2, {"gil", 250000}}, reward = {afHQ[1] + 2, afHQ[2] + 2, afHQ[3] + 2, afHQ[4] + 2, afHQ[5] + 2}}, -- WHM
-		[  4] = {trade = {af[1] + 1345, af[2] + 3, af[3] + 3, af[4] + 3, af[5] + 3, {"gil", 250000}}, reward = {afHQ[1] + 3, afHQ[2] + 3, afHQ[3] + 3, afHQ[4] + 3, afHQ[5] + 3}}, -- BLM
-		[  5] = {trade = {af[1] + 2, af[2] + 4, af[3] + 4, af[4] + 4, af[5] + 4, {"gil", 250000}}, reward = {afHQ[1] + 4, afHQ[2] + 4, afHQ[3] + 4, afHQ[4] + 4, afHQ[5] + 4}}, -- RDM
-		[  6] = {trade = {af[1] + 3, af[2] + 5, af[3] + 5, af[4] + 5, af[5] + 5, {"gil", 250000}}, reward = {afHQ[1] + 5, afHQ[2] + 5, afHQ[3] + 5, afHQ[4] + 5, afHQ[5] + 5}}, -- THF
-		[  7] = {trade = {af[1] + 4, af[2] + 6, af[3] + 6, af[4] + 6, af[5] + 6, {"gil", 250000}}, reward = {afHQ[1] + 6, afHQ[2] + 6, afHQ[3] + 6, afHQ[4] + 6, afHQ[5] + 6}}, -- PLD
-		[  8] = {trade = {af[1] + 5, af[2] + 7, af[3] + 7, af[4] + 7, af[5] + 7, {"gil", 250000}}, reward = {afHQ[1] + 7, afHQ[2] + 7, afHQ[3] + 7, afHQ[4] + 7, afHQ[5] + 7}}, -- DRK
-		[  9] = {trade = {af[1] + 6, af[2] + 8, af[3] + 8, af[4] + 8, af[5] + 8, {"gil", 250000}}, reward = {afHQ[1] + 8, afHQ[2] + 8, afHQ[3] + 8, afHQ[4] + 8, afHQ[5] + 8}}, -- BST
-		[ 10] = {trade = {af[1] + 1346, af[2] + 9, af[3] + 9, af[4] + 9, af[5] + 9, {"gil", 250000}}, reward = {afHQ[1] + 9, afHQ[2] + 9, afHQ[3] + 9, afHQ[4] + 9, afHQ[5] + 9}}, -- BRD
-		[ 11] = {trade = {af[1] + 7, af[2] + 10, af[3] + 10, af[4] + 10, af[5] + 10, {"gil", 250000}}, reward = {afHQ[1] + 10, afHQ[2] + 10, afHQ[3] + 10, afHQ[4] + 10, afHQ[5] + 10}}, -- RNG
-		[ 12] = {trade = {af[1] + 1357, af[2] + 1143, af[3] + 11, af[4] + 11, af[5] + 11, {"gil", 250000}}, reward = {afHQ[1] + 11, afHQ[2] + 11, afHQ[3] + 11, afHQ[4] + 11, afHQ[5] + 11}}, -- SAM
-		[ 13] = {trade = {af[1] + 1358, af[2] + 1144, af[3] + 12, af[4] + 12, af[5] + 12, {"gil", 250000}}, reward = {afHQ[1] + 12, afHQ[2] + 12, afHQ[3] + 12, afHQ[4] + 12, afHQ[5] + 12}}, -- NIN
-		[ 14] = {trade = {af[1] + 8, af[2] + 11, af[3] + 13, af[4] + 13, af[5] + 13, {"gil", 250000}}, reward = {afHQ[1] + 13, afHQ[2] + 13, afHQ[3] + 13, afHQ[4] + 13, afHQ[5] + 13}}, -- DRG
-		[ 15] = {trade = {af[1] + 9, af[2] + 12, af[3] + 14, af[4] + 14, af[5] + 14, {"gil", 250000}}, reward = {afHQ[1] + 14, afHQ[2] + 14, afHQ[3] + 14, afHQ[4] + 14, afHQ[5] + 14}}, -- SMN
-		[ 16] = {trade = {af[1] + 2754, af[2] + 1883, af[3] + 967, af[4] + 1511, af[5] + 1470, {"gil", 250000}}, reward = {afHQ[1] - 3761, afHQ[2] - 3182, afHQ[3] + 134, afHQ[4] + 784, afHQ[5] - 3971}}, -- BLU
-		[ 17] = {trade = {af[1] + 2755, af[2] + 1884, af[3] + 968, af[4] + 1512, af[5] + 1471, {"gil", 250000}}, reward = {afHQ[1] - 3758, afHQ[2] - 3179, afHQ[3] + 137, afHQ[4] + 787, afHQ[5] - 3968}}, -- COR
-		[ 18] = {trade = {af[1] + 2756, af[2] + 1885, af[3] + 969, af[4] + 1513, af[5] + 1472, {"gil", 250000}}, reward = {afHQ[1] - 3755, afHQ[2] - 3176, afHQ[3] + 140, afHQ[4] + 790, afHQ[5] - 3965}}, -- PUP
-		[ 19] = {trade = {af[1] + 3627, af[2] + 1940, af[3] + 1041, af[4] + 1570, af[5] + 1532, {"gil", 250000}}, reward = {afHQ[1] - 3750, afHQ[2] - 3171, afHQ[3] + 145, afHQ[4] + 796, afHQ[5] - 3959}}, -- DNC (Male)
-		[ 20] = {trade = {af[1] + 3628, af[2] + 1941, af[3] + 1042, af[4] + 1571, af[5] + 1533, {"gil", 250000}}, reward = {afHQ[1] - 3749, afHQ[2] - 3170, afHQ[3] + 146, afHQ[4] + 797, afHQ[5] - 3958}}, -- DNC (Female)
-		[ 21] = {trade = {af[1] + 3629, af[2] + 1942, af[3] + 1043, af[4] + 2222, af[5] + 1534, {"gil", 250000}}, reward = {afHQ[1] - 3748, afHQ[2] - 3169, afHQ[3] + 147, afHQ[4] + 798, afHQ[5] - 3957}}, -- SCH
-	}
-	
-	local tradedCombo = 0
+    local artifactArmor = {
+        [  1] = {trade = {af[1], af[2], af[3], af[4], af[5], {"gil", 250000}}, reward = {afHQ[1], afHQ[2], afHQ[3], afHQ[4], afHQ[5]}}, -- WAR
+        [  2] = {trade = {af[1] + 1, af[2] + 1, af[3] + 1, af[4] + 1, af[5] + 1, {"gil", 250000}}, reward = {afHQ[1] + 1, afHQ[2] + 1, afHQ[3] + 1, afHQ[4] + 1, afHQ[5] + 1}}, -- MNK
+        [  3] = {trade = {af[1] + 1344, af[2] + 2, af[3] + 2, af[4] + 2, af[5] + 2, {"gil", 250000}}, reward = {afHQ[1] + 2, afHQ[2] + 2, afHQ[3] + 2, afHQ[4] + 2, afHQ[5] + 2}}, -- WHM
+        [  4] = {trade = {af[1] + 1345, af[2] + 3, af[3] + 3, af[4] + 3, af[5] + 3, {"gil", 250000}}, reward = {afHQ[1] + 3, afHQ[2] + 3, afHQ[3] + 3, afHQ[4] + 3, afHQ[5] + 3}}, -- BLM
+        [  5] = {trade = {af[1] + 2, af[2] + 4, af[3] + 4, af[4] + 4, af[5] + 4, {"gil", 250000}}, reward = {afHQ[1] + 4, afHQ[2] + 4, afHQ[3] + 4, afHQ[4] + 4, afHQ[5] + 4}}, -- RDM
+        [  6] = {trade = {af[1] + 3, af[2] + 5, af[3] + 5, af[4] + 5, af[5] + 5, {"gil", 250000}}, reward = {afHQ[1] + 5, afHQ[2] + 5, afHQ[3] + 5, afHQ[4] + 5, afHQ[5] + 5}}, -- THF
+        [  7] = {trade = {af[1] + 4, af[2] + 6, af[3] + 6, af[4] + 6, af[5] + 6, {"gil", 250000}}, reward = {afHQ[1] + 6, afHQ[2] + 6, afHQ[3] + 6, afHQ[4] + 6, afHQ[5] + 6}}, -- PLD
+        [  8] = {trade = {af[1] + 5, af[2] + 7, af[3] + 7, af[4] + 7, af[5] + 7, {"gil", 250000}}, reward = {afHQ[1] + 7, afHQ[2] + 7, afHQ[3] + 7, afHQ[4] + 7, afHQ[5] + 7}}, -- DRK
+        [  9] = {trade = {af[1] + 6, af[2] + 8, af[3] + 8, af[4] + 8, af[5] + 8, {"gil", 250000}}, reward = {afHQ[1] + 8, afHQ[2] + 8, afHQ[3] + 8, afHQ[4] + 8, afHQ[5] + 8}}, -- BST
+        [ 10] = {trade = {af[1] + 1346, af[2] + 9, af[3] + 9, af[4] + 9, af[5] + 9, {"gil", 250000}}, reward = {afHQ[1] + 9, afHQ[2] + 9, afHQ[3] + 9, afHQ[4] + 9, afHQ[5] + 9}}, -- BRD
+        [ 11] = {trade = {af[1] + 7, af[2] + 10, af[3] + 10, af[4] + 10, af[5] + 10, {"gil", 250000}}, reward = {afHQ[1] + 10, afHQ[2] + 10, afHQ[3] + 10, afHQ[4] + 10, afHQ[5] + 10}}, -- RNG
+        [ 12] = {trade = {af[1] + 1357, af[2] + 1143, af[3] + 11, af[4] + 11, af[5] + 11, {"gil", 250000}}, reward = {afHQ[1] + 11, afHQ[2] + 11, afHQ[3] + 11, afHQ[4] + 11, afHQ[5] + 11}}, -- SAM
+        [ 13] = {trade = {af[1] + 1358, af[2] + 1144, af[3] + 12, af[4] + 12, af[5] + 12, {"gil", 250000}}, reward = {afHQ[1] + 12, afHQ[2] + 12, afHQ[3] + 12, afHQ[4] + 12, afHQ[5] + 12}}, -- NIN
+        [ 14] = {trade = {af[1] + 8, af[2] + 11, af[3] + 13, af[4] + 13, af[5] + 13, {"gil", 250000}}, reward = {afHQ[1] + 13, afHQ[2] + 13, afHQ[3] + 13, afHQ[4] + 13, afHQ[5] + 13}}, -- DRG
+        [ 15] = {trade = {af[1] + 9, af[2] + 12, af[3] + 14, af[4] + 14, af[5] + 14, {"gil", 250000}}, reward = {afHQ[1] + 14, afHQ[2] + 14, afHQ[3] + 14, afHQ[4] + 14, afHQ[5] + 14}}, -- SMN
+        [ 16] = {trade = {af[1] + 2754, af[2] + 1883, af[3] + 967, af[4] + 1511, af[5] + 1470, {"gil", 250000}}, reward = {afHQ[1] - 3761, afHQ[2] - 3182, afHQ[3] + 134, afHQ[4] + 784, afHQ[5] - 3971}}, -- BLU
+        [ 17] = {trade = {af[1] + 2755, af[2] + 1884, af[3] + 968, af[4] + 1512, af[5] + 1471, {"gil", 250000}}, reward = {afHQ[1] - 3758, afHQ[2] - 3179, afHQ[3] + 137, afHQ[4] + 787, afHQ[5] - 3968}}, -- COR
+        [ 18] = {trade = {af[1] + 2756, af[2] + 1885, af[3] + 969, af[4] + 1513, af[5] + 1472, {"gil", 250000}}, reward = {afHQ[1] - 3755, afHQ[2] - 3176, afHQ[3] + 140, afHQ[4] + 790, afHQ[5] - 3965}}, -- PUP
+        [ 19] = {trade = {af[1] + 3627, af[2] + 1940, af[3] + 1041, af[4] + 1570, af[5] + 1532, {"gil", 250000}}, reward = {afHQ[1] - 3750, afHQ[2] - 3171, afHQ[3] + 145, afHQ[4] + 796, afHQ[5] - 3959}}, -- DNC (Male)
+        [ 20] = {trade = {af[1] + 3628, af[2] + 1941, af[3] + 1042, af[4] + 1571, af[5] + 1533, {"gil", 250000}}, reward = {afHQ[1] - 3749, afHQ[2] - 3170, afHQ[3] + 146, afHQ[4] + 797, afHQ[5] - 3958}}, -- DNC (Female)
+        [ 21] = {trade = {af[1] + 3629, af[2] + 1942, af[3] + 1043, af[4] + 2222, af[5] + 1534, {"gil", 250000}}, reward = {afHQ[1] - 3748, afHQ[2] - 3169, afHQ[3] + 147, afHQ[4] + 798, afHQ[5] - 3957}}, -- SCH
+    }
+    
+    local tradedCombo = 0
 
-	-- Check for Reforged Artifact armor trade combination
-	if tradedCombo == 0 then
-		for k, v in pairs(artifactArmor) do
-			if npcUtil.tradeHasExactly(trade, v.trade) then
-				tradedCombo = k
-				break
-			end
-		end
-	end
-	
-	-- Found a match
-	if tradedCombo > 0 then
-		local ID = zones[player:getZoneID()]
-		
-		for i = 1, #artifactArmor[tradedCombo].reward do
-			local reward = artifactArmor[tradedCombo].reward[i]
-		
-			player:confirmTrade()
-			player:addItem(reward)
-			player:delGil(50000)
-			player:messageSpecial(ID.text.ITEM_OBTAINED, reward)
-		end
-	end
+    -- Check for Reforged Artifact armor trade combination
+    if tradedCombo == 0 then
+        for k, v in pairs(artifactArmor) do
+            if npcUtil.tradeHasExactly(trade, v.trade) then
+                tradedCombo = k
+                break
+            end
+        end
+    end
+    
+    -- Found a match
+    if tradedCombo > 0 then
+        local ID = zones[player:getZoneID()]
+        
+        for i = 1, #artifactArmor[tradedCombo].reward do
+            local reward = artifactArmor[tradedCombo].reward[i]
+        
+            player:confirmTrade()
+            player:addItem(reward)
+            player:delGil(50000)
+            player:messageSpecial(ID.text.ITEM_OBTAINED, reward)
+        end
+    end
 end)
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	local job = player:getMainJob()
-	local level = player:getMainLvl()
-	
-	if (level >= 51) then
-		if (job == xi.job.WAR and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(12511, 1)
-			player:addItem(12638, 1)
-			player:addItem(13961, 1)
-			player:addItem(14214, 1)
-			player:addItem(14089, 1)
-			player:PrintToPlayer(string.format("Obtained the Fighter's Armor Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.MNK and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(12512, 1)
-			player:addItem(12639, 1)
-			player:addItem(13962, 1)
-			player:addItem(14215, 1)
-			player:addItem(14090, 1)
-			player:PrintToPlayer(string.format("Obtained the Temple Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.WHM and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(13855, 1)
-			player:addItem(12640, 1)
-			player:addItem(13963, 1)
-			player:addItem(14216, 1)
-			player:addItem(14091, 1)
-			player:PrintToPlayer(string.format("Obtained the Healer's Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.BLM and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(13856, 1)
-			player:addItem(12641, 1)
-			player:addItem(13964, 1)
-			player:addItem(14217, 1)
-			player:addItem(14092, 1)
-			player:PrintToPlayer(string.format("Obtained the Wizard's Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.RDM and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(12513, 1)
-			player:addItem(12642, 1)
-			player:addItem(13965, 1)
-			player:addItem(14218, 1)
-			player:addItem(14093, 1)
-			player:PrintToPlayer(string.format("Obtained the Warlock's Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.THF and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(12514, 1)
-			player:addItem(12643, 1)
-			player:addItem(13966, 1)
-			player:addItem(14219, 1)
-			player:addItem(14094, 1)
-			player:PrintToPlayer(string.format("Obtained the Rogue's Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.PLD and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(12515, 1)
-			player:addItem(12644, 1)
-			player:addItem(13967, 1)
-			player:addItem(14220, 1)
-			player:addItem(14095, 1)
-			player:PrintToPlayer(string.format("Obtained the Gallant Armor Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.DRK and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(12516, 1)
-			player:addItem(12645, 1)
-			player:addItem(13968, 1)
-			player:addItem(14221, 1)
-			player:addItem(14096, 1)
-			player:PrintToPlayer(string.format("Obtained the Chaos Armor Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.BST and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(12517, 1)
-			player:addItem(12646, 1)
-			player:addItem(13969, 1)
-			player:addItem(14222, 1)
-			player:addItem(14097, 1)
-			player:PrintToPlayer(string.format("Obtained the Beast Armor Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.BRD and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(13857, 1)
-			player:addItem(12647, 1)
-			player:addItem(13970, 1)
-			player:addItem(14223, 1)
-			player:addItem(14098, 1)
-			player:PrintToPlayer(string.format("Obtained the Choral Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.RNG and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(12518, 1)
-			player:addItem(12648, 1)
-			player:addItem(13971, 1)
-			player:addItem(14224, 1)
-			player:addItem(14099, 1)
-			player:PrintToPlayer(string.format("Obtained the Hunter's Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.SAM and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(13868, 1)
-			player:addItem(13781, 1)
-			player:addItem(13972, 1)
-			player:addItem(14225, 1)
-			player:addItem(14100, 1)
-			player:PrintToPlayer(string.format("Obtained the Myochin Armor Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.NIN and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(13869, 1)
-			player:addItem(13782, 1)
-			player:addItem(13973, 1)
-			player:addItem(14226, 1)
-			player:addItem(14101, 1)
-			player:PrintToPlayer(string.format("Obtained the Ninja Garb Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.DRG and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(12519, 1)
-			player:addItem(12649, 1)
-			player:addItem(13974, 1)
-			player:addItem(14227, 1)
-			player:addItem(14102, 1)
-			player:PrintToPlayer(string.format("Obtained the Drachen Armor Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.SMN and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(12520, 1)
-			player:addItem(12650, 1)
-			player:addItem(13975, 1)
-			player:addItem(14228, 1)
-			player:addItem(14103, 1)
-			player:PrintToPlayer(string.format("Obtained the Evoker's Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.BLU and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(15265, 1)
-			player:addItem(14521, 1)
-			player:addItem(14928, 1)
-			player:addItem(15600, 1)
-			player:addItem(15684, 1)
-			player:PrintToPlayer(string.format("Obtained the Magus Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.COR and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(15266, 1)
-			player:addItem(14522, 1)
-			player:addItem(14929, 1)
-			player:addItem(15601, 1)
-			player:addItem(15685, 1)
-			player:PrintToPlayer(string.format("Obtained the Corsair's Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.PUP and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(15267, 1)
-			player:addItem(14523, 1)
-			player:addItem(14930, 1)
-			player:addItem(15602, 1)
-			player:addItem(15686, 1)
-			player:PrintToPlayer(string.format("Obtained the Puppetry Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.DNC and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			if (player:getRace() == xi.race.HUME_M or player:getRace() == xi.race.ELVAAN_M or player:getRace() == xi.race.TARU_M or player:getRace() == xi.race.GALKA) then
-				player:addItem(16138, 1)
-				player:addItem(14578, 1)
-				player:addItem(15002, 1)
-				player:addItem(15659, 1)
-				player:addItem(15746, 1)
-				player:PrintToPlayer(string.format("Obtained the Male Dancer's Attire Set!"),xi.msg.channel.SYSTEM_3)
-			else
-				player:addItem(16139, 1)
-				player:addItem(14579, 1)
-				player:addItem(15003, 1)
-				player:addItem(15660, 1)
-				player:addItem(15747, 1)
-				player:PrintToPlayer(string.format("Obtained the Female Dancer's Attire Set!"),xi.msg.channel.SYSTEM_3)
-			end
-		elseif (job == xi.job.SCH and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(16140, 1)
-			player:addItem(14580, 1)
-			player:addItem(15004, 1)
-			player:addItem(16311, 1)
-			player:addItem(15748, 1)
-			player:PrintToPlayer(string.format("Obtained the Scholar's Attire Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.GEO and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(16143, 1, 1, 9, 131, 2) -- +10 MP/+3 MACC/+3 MAB
-			player:addItem(14583, 1, 9, 9, 131, 4) -- +10 HP/+5 MACC/+5 MAB
-			player:addItem(15007, 1, 23, 4, 301, 9) -- +5 ACC/+10 Handbell Skill
-			player:addItem(16314, 1, 112, 2, 300, 9) -- -3% Pet DT/+10 Geomancy Skill
-			player:addItem(15751, 1, 110, 1, 292, 9) -- +2 Pet Regen/+10 Elemental Magic Skill
-			player:PrintToPlayer(string.format("Obtained the GEO augmented Cobra Unit Set!"),xi.msg.channel.SYSTEM_3)
-		elseif (job == xi.job.RUN and level >= 51 and player:getFreeSlotsCount() >= 5) then
-			player:addItem(16143, 1, 513, 1, 23, 4) -- +2 DEX/+5 ACC
-			player:addItem(14583, 1, 514, 2, 17, 9) -- +3 VIT/+10 HP/+10 MP
-			player:addItem(15007, 1, 512, 1, 25, 9) -- +2 STR/+10 ATK
-			player:addItem(16314, 1, 31, 4, 39, 4) -- +5 EVA/+5 Enmity
-			player:addItem(15751, 1, 37, 4, 134, 2) -- +5 MEVA/+3 MDEF
-			player:PrintToPlayer(string.format("Obtained the RUN augmented Cobra Unit Set!"),xi.msg.channel.SYSTEM_3)
-		else
-			player:PrintToPlayer(string.format("Please clear inventory slots and try again!"),xi.msg.channel.SYSTEM_3)
-		end
-	else
-		player:PrintToPlayer(string.format("You can claim a full set of your job's artifact armor from here after level 51."),xi.msg.channel.SYSTEM_3)
-	end
+    local job = player:getMainJob()
+    local level = player:getMainLvl()
+    
+    if (level >= 51) then
+        if (job == xi.job.WAR and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(12511, 1)
+            player:addItem(12638, 1)
+            player:addItem(13961, 1)
+            player:addItem(14214, 1)
+            player:addItem(14089, 1)
+            player:PrintToPlayer(string.format("Obtained the Fighter's Armor Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.MNK and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(12512, 1)
+            player:addItem(12639, 1)
+            player:addItem(13962, 1)
+            player:addItem(14215, 1)
+            player:addItem(14090, 1)
+            player:PrintToPlayer(string.format("Obtained the Temple Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.WHM and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(13855, 1)
+            player:addItem(12640, 1)
+            player:addItem(13963, 1)
+            player:addItem(14216, 1)
+            player:addItem(14091, 1)
+            player:PrintToPlayer(string.format("Obtained the Healer's Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.BLM and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(13856, 1)
+            player:addItem(12641, 1)
+            player:addItem(13964, 1)
+            player:addItem(14217, 1)
+            player:addItem(14092, 1)
+            player:PrintToPlayer(string.format("Obtained the Wizard's Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.RDM and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(12513, 1)
+            player:addItem(12642, 1)
+            player:addItem(13965, 1)
+            player:addItem(14218, 1)
+            player:addItem(14093, 1)
+            player:PrintToPlayer(string.format("Obtained the Warlock's Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.THF and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(12514, 1)
+            player:addItem(12643, 1)
+            player:addItem(13966, 1)
+            player:addItem(14219, 1)
+            player:addItem(14094, 1)
+            player:PrintToPlayer(string.format("Obtained the Rogue's Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.PLD and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(12515, 1)
+            player:addItem(12644, 1)
+            player:addItem(13967, 1)
+            player:addItem(14220, 1)
+            player:addItem(14095, 1)
+            player:PrintToPlayer(string.format("Obtained the Gallant Armor Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.DRK and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(12516, 1)
+            player:addItem(12645, 1)
+            player:addItem(13968, 1)
+            player:addItem(14221, 1)
+            player:addItem(14096, 1)
+            player:PrintToPlayer(string.format("Obtained the Chaos Armor Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.BST and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(12517, 1)
+            player:addItem(12646, 1)
+            player:addItem(13969, 1)
+            player:addItem(14222, 1)
+            player:addItem(14097, 1)
+            player:PrintToPlayer(string.format("Obtained the Beast Armor Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.BRD and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(13857, 1)
+            player:addItem(12647, 1)
+            player:addItem(13970, 1)
+            player:addItem(14223, 1)
+            player:addItem(14098, 1)
+            player:PrintToPlayer(string.format("Obtained the Choral Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.RNG and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(12518, 1)
+            player:addItem(12648, 1)
+            player:addItem(13971, 1)
+            player:addItem(14224, 1)
+            player:addItem(14099, 1)
+            player:PrintToPlayer(string.format("Obtained the Hunter's Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.SAM and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(13868, 1)
+            player:addItem(13781, 1)
+            player:addItem(13972, 1)
+            player:addItem(14225, 1)
+            player:addItem(14100, 1)
+            player:PrintToPlayer(string.format("Obtained the Myochin Armor Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.NIN and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(13869, 1)
+            player:addItem(13782, 1)
+            player:addItem(13973, 1)
+            player:addItem(14226, 1)
+            player:addItem(14101, 1)
+            player:PrintToPlayer(string.format("Obtained the Ninja Garb Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.DRG and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(12519, 1)
+            player:addItem(12649, 1)
+            player:addItem(13974, 1)
+            player:addItem(14227, 1)
+            player:addItem(14102, 1)
+            player:PrintToPlayer(string.format("Obtained the Drachen Armor Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.SMN and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(12520, 1)
+            player:addItem(12650, 1)
+            player:addItem(13975, 1)
+            player:addItem(14228, 1)
+            player:addItem(14103, 1)
+            player:PrintToPlayer(string.format("Obtained the Evoker's Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.BLU and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(15265, 1)
+            player:addItem(14521, 1)
+            player:addItem(14928, 1)
+            player:addItem(15600, 1)
+            player:addItem(15684, 1)
+            player:PrintToPlayer(string.format("Obtained the Magus Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.COR and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(15266, 1)
+            player:addItem(14522, 1)
+            player:addItem(14929, 1)
+            player:addItem(15601, 1)
+            player:addItem(15685, 1)
+            player:PrintToPlayer(string.format("Obtained the Corsair's Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.PUP and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(15267, 1)
+            player:addItem(14523, 1)
+            player:addItem(14930, 1)
+            player:addItem(15602, 1)
+            player:addItem(15686, 1)
+            player:PrintToPlayer(string.format("Obtained the Puppetry Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.DNC and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            if (player:getRace() == xi.race.HUME_M or player:getRace() == xi.race.ELVAAN_M or player:getRace() == xi.race.TARU_M or player:getRace() == xi.race.GALKA) then
+                player:addItem(16138, 1)
+                player:addItem(14578, 1)
+                player:addItem(15002, 1)
+                player:addItem(15659, 1)
+                player:addItem(15746, 1)
+                player:PrintToPlayer(string.format("Obtained the Male Dancer's Attire Set!"),xi.msg.channel.SYSTEM_3)
+            else
+                player:addItem(16139, 1)
+                player:addItem(14579, 1)
+                player:addItem(15003, 1)
+                player:addItem(15660, 1)
+                player:addItem(15747, 1)
+                player:PrintToPlayer(string.format("Obtained the Female Dancer's Attire Set!"),xi.msg.channel.SYSTEM_3)
+            end
+        elseif (job == xi.job.SCH and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(16140, 1)
+            player:addItem(14580, 1)
+            player:addItem(15004, 1)
+            player:addItem(16311, 1)
+            player:addItem(15748, 1)
+            player:PrintToPlayer(string.format("Obtained the Scholar's Attire Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.GEO and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(16143, 1, 1, 9, 131, 2) -- +10 MP/+3 MACC/+3 MAB
+            player:addItem(14583, 1, 9, 9, 131, 4) -- +10 HP/+5 MACC/+5 MAB
+            player:addItem(15007, 1, 23, 4, 301, 9) -- +5 ACC/+10 Handbell Skill
+            player:addItem(16314, 1, 112, 2, 300, 9) -- -3% Pet DT/+10 Geomancy Skill
+            player:addItem(15751, 1, 110, 1, 292, 9) -- +2 Pet Regen/+10 Elemental Magic Skill
+            player:PrintToPlayer(string.format("Obtained the GEO augmented Cobra Unit Set!"),xi.msg.channel.SYSTEM_3)
+        elseif (job == xi.job.RUN and level >= 51 and player:getFreeSlotsCount() >= 5) then
+            player:addItem(16143, 1, 513, 1, 23, 4) -- +2 DEX/+5 ACC
+            player:addItem(14583, 1, 514, 2, 17, 9) -- +3 VIT/+10 HP/+10 MP
+            player:addItem(15007, 1, 512, 1, 25, 9) -- +2 STR/+10 ATK
+            player:addItem(16314, 1, 31, 4, 39, 4) -- +5 EVA/+5 Enmity
+            player:addItem(15751, 1, 37, 4, 134, 2) -- +5 MEVA/+3 MDEF
+            player:PrintToPlayer(string.format("Obtained the RUN augmented Cobra Unit Set!"),xi.msg.channel.SYSTEM_3)
+        else
+            player:PrintToPlayer(string.format("Please clear inventory slots and try again!"),xi.msg.channel.SYSTEM_3)
+        end
+    else
+        player:PrintToPlayer(string.format("You can claim a full set of your job's artifact armor from here after level 51."),xi.msg.channel.SYSTEM_3)
+    end
 end)
 
 return m 
-

--- a/modules/custom/lua/caldera_npc_module/Personages.lua
+++ b/modules/custom/lua/caldera_npc_module/Personages.lua
@@ -1,0 +1,250 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Personages
+-- !pos -103 -2 -106 51
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
+require("scripts/globals/npc_util")
+require("modules/module_utils")
+-----------------------------------
+
+local m = Module:new("Personages")
+
+local npcToReplaceName = "Personages"
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrade", npcToReplaceName), function(player,npc,trade)
+	local af = {12511, 12638, 13961, 14089, 14214}
+	local afHQ = {15225, 14473, 14890, 15561, 15352}
+
+	local artifactArmor = {
+		[  1] = {trade = {af[1], af[2], af[3], af[4], af[5], {"gil", 250000}}, reward = {afHQ[1], afHQ[2], afHQ[3], afHQ[4], afHQ[5]}}, -- WAR
+		[  2] = {trade = {af[1] + 1, af[2] + 1, af[3] + 1, af[4] + 1, af[5] + 1, {"gil", 250000}}, reward = {afHQ[1] + 1, afHQ[2] + 1, afHQ[3] + 1, afHQ[4] + 1, afHQ[5] + 1}}, -- MNK
+		[  3] = {trade = {af[1] + 1344, af[2] + 2, af[3] + 2, af[4] + 2, af[5] + 2, {"gil", 250000}}, reward = {afHQ[1] + 2, afHQ[2] + 2, afHQ[3] + 2, afHQ[4] + 2, afHQ[5] + 2}}, -- WHM
+		[  4] = {trade = {af[1] + 1345, af[2] + 3, af[3] + 3, af[4] + 3, af[5] + 3, {"gil", 250000}}, reward = {afHQ[1] + 3, afHQ[2] + 3, afHQ[3] + 3, afHQ[4] + 3, afHQ[5] + 3}}, -- BLM
+		[  5] = {trade = {af[1] + 2, af[2] + 4, af[3] + 4, af[4] + 4, af[5] + 4, {"gil", 250000}}, reward = {afHQ[1] + 4, afHQ[2] + 4, afHQ[3] + 4, afHQ[4] + 4, afHQ[5] + 4}}, -- RDM
+		[  6] = {trade = {af[1] + 3, af[2] + 5, af[3] + 5, af[4] + 5, af[5] + 5, {"gil", 250000}}, reward = {afHQ[1] + 5, afHQ[2] + 5, afHQ[3] + 5, afHQ[4] + 5, afHQ[5] + 5}}, -- THF
+		[  7] = {trade = {af[1] + 4, af[2] + 6, af[3] + 6, af[4] + 6, af[5] + 6, {"gil", 250000}}, reward = {afHQ[1] + 6, afHQ[2] + 6, afHQ[3] + 6, afHQ[4] + 6, afHQ[5] + 6}}, -- PLD
+		[  8] = {trade = {af[1] + 5, af[2] + 7, af[3] + 7, af[4] + 7, af[5] + 7, {"gil", 250000}}, reward = {afHQ[1] + 7, afHQ[2] + 7, afHQ[3] + 7, afHQ[4] + 7, afHQ[5] + 7}}, -- DRK
+		[  9] = {trade = {af[1] + 6, af[2] + 8, af[3] + 8, af[4] + 8, af[5] + 8, {"gil", 250000}}, reward = {afHQ[1] + 8, afHQ[2] + 8, afHQ[3] + 8, afHQ[4] + 8, afHQ[5] + 8}}, -- BST
+		[ 10] = {trade = {af[1] + 1346, af[2] + 9, af[3] + 9, af[4] + 9, af[5] + 9, {"gil", 250000}}, reward = {afHQ[1] + 9, afHQ[2] + 9, afHQ[3] + 9, afHQ[4] + 9, afHQ[5] + 9}}, -- BRD
+		[ 11] = {trade = {af[1] + 7, af[2] + 10, af[3] + 10, af[4] + 10, af[5] + 10, {"gil", 250000}}, reward = {afHQ[1] + 10, afHQ[2] + 10, afHQ[3] + 10, afHQ[4] + 10, afHQ[5] + 10}}, -- RNG
+		[ 12] = {trade = {af[1] + 1357, af[2] + 1143, af[3] + 11, af[4] + 11, af[5] + 11, {"gil", 250000}}, reward = {afHQ[1] + 11, afHQ[2] + 11, afHQ[3] + 11, afHQ[4] + 11, afHQ[5] + 11}}, -- SAM
+		[ 13] = {trade = {af[1] + 1358, af[2] + 1144, af[3] + 12, af[4] + 12, af[5] + 12, {"gil", 250000}}, reward = {afHQ[1] + 12, afHQ[2] + 12, afHQ[3] + 12, afHQ[4] + 12, afHQ[5] + 12}}, -- NIN
+		[ 14] = {trade = {af[1] + 8, af[2] + 11, af[3] + 13, af[4] + 13, af[5] + 13, {"gil", 250000}}, reward = {afHQ[1] + 13, afHQ[2] + 13, afHQ[3] + 13, afHQ[4] + 13, afHQ[5] + 13}}, -- DRG
+		[ 15] = {trade = {af[1] + 9, af[2] + 12, af[3] + 14, af[4] + 14, af[5] + 14, {"gil", 250000}}, reward = {afHQ[1] + 14, afHQ[2] + 14, afHQ[3] + 14, afHQ[4] + 14, afHQ[5] + 14}}, -- SMN
+		[ 16] = {trade = {af[1] + 2754, af[2] + 1883, af[3] + 967, af[4] + 1511, af[5] + 1470, {"gil", 250000}}, reward = {afHQ[1] - 3761, afHQ[2] - 3182, afHQ[3] + 134, afHQ[4] + 784, afHQ[5] - 3971}}, -- BLU
+		[ 17] = {trade = {af[1] + 2755, af[2] + 1884, af[3] + 968, af[4] + 1512, af[5] + 1471, {"gil", 250000}}, reward = {afHQ[1] - 3758, afHQ[2] - 3179, afHQ[3] + 137, afHQ[4] + 787, afHQ[5] - 3968}}, -- COR
+		[ 18] = {trade = {af[1] + 2756, af[2] + 1885, af[3] + 969, af[4] + 1513, af[5] + 1472, {"gil", 250000}}, reward = {afHQ[1] - 3755, afHQ[2] - 3176, afHQ[3] + 140, afHQ[4] + 790, afHQ[5] - 3965}}, -- PUP
+		[ 19] = {trade = {af[1] + 3627, af[2] + 1940, af[3] + 1041, af[4] + 1570, af[5] + 1532, {"gil", 250000}}, reward = {afHQ[1] - 3750, afHQ[2] - 3171, afHQ[3] + 145, afHQ[4] + 796, afHQ[5] - 3959}}, -- DNC (Male)
+		[ 20] = {trade = {af[1] + 3628, af[2] + 1941, af[3] + 1042, af[4] + 1571, af[5] + 1533, {"gil", 250000}}, reward = {afHQ[1] - 3749, afHQ[2] - 3170, afHQ[3] + 146, afHQ[4] + 797, afHQ[5] - 3958}}, -- DNC (Female)
+		[ 21] = {trade = {af[1] + 3629, af[2] + 1942, af[3] + 1043, af[4] + 2222, af[5] + 1534, {"gil", 250000}}, reward = {afHQ[1] - 3748, afHQ[2] - 3169, afHQ[3] + 147, afHQ[4] + 798, afHQ[5] - 3957}}, -- SCH
+	}
+	
+	local tradedCombo = 0
+
+	-- Check for Reforged Artifact armor trade combination
+	if tradedCombo == 0 then
+		for k, v in pairs(artifactArmor) do
+			if npcUtil.tradeHasExactly(trade, v.trade) then
+				tradedCombo = k
+				break
+			end
+		end
+	end
+	
+	-- Found a match
+	if tradedCombo > 0 then
+		local ID = zones[player:getZoneID()]
+		
+		for i = 1, #artifactArmor[tradedCombo].reward do
+			local reward = artifactArmor[tradedCombo].reward[i]
+		
+			player:confirmTrade()
+			player:addItem(reward)
+			player:delGil(50000)
+			player:messageSpecial(ID.text.ITEM_OBTAINED, reward)
+		end
+	end
+end)
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	local job = player:getMainJob()
+	local level = player:getMainLvl()
+	
+	if (level >= 51) then
+		if (job == xi.job.WAR and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(12511, 1)
+			player:addItem(12638, 1)
+			player:addItem(13961, 1)
+			player:addItem(14214, 1)
+			player:addItem(14089, 1)
+			player:PrintToPlayer(string.format("Obtained the Fighter's Armor Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.MNK and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(12512, 1)
+			player:addItem(12639, 1)
+			player:addItem(13962, 1)
+			player:addItem(14215, 1)
+			player:addItem(14090, 1)
+			player:PrintToPlayer(string.format("Obtained the Temple Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.WHM and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(13855, 1)
+			player:addItem(12640, 1)
+			player:addItem(13963, 1)
+			player:addItem(14216, 1)
+			player:addItem(14091, 1)
+			player:PrintToPlayer(string.format("Obtained the Healer's Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.BLM and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(13856, 1)
+			player:addItem(12641, 1)
+			player:addItem(13964, 1)
+			player:addItem(14217, 1)
+			player:addItem(14092, 1)
+			player:PrintToPlayer(string.format("Obtained the Wizard's Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.RDM and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(12513, 1)
+			player:addItem(12642, 1)
+			player:addItem(13965, 1)
+			player:addItem(14218, 1)
+			player:addItem(14093, 1)
+			player:PrintToPlayer(string.format("Obtained the Warlock's Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.THF and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(12514, 1)
+			player:addItem(12643, 1)
+			player:addItem(13966, 1)
+			player:addItem(14219, 1)
+			player:addItem(14094, 1)
+			player:PrintToPlayer(string.format("Obtained the Rogue's Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.PLD and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(12515, 1)
+			player:addItem(12644, 1)
+			player:addItem(13967, 1)
+			player:addItem(14220, 1)
+			player:addItem(14095, 1)
+			player:PrintToPlayer(string.format("Obtained the Gallant Armor Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.DRK and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(12516, 1)
+			player:addItem(12645, 1)
+			player:addItem(13968, 1)
+			player:addItem(14221, 1)
+			player:addItem(14096, 1)
+			player:PrintToPlayer(string.format("Obtained the Chaos Armor Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.BST and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(12517, 1)
+			player:addItem(12646, 1)
+			player:addItem(13969, 1)
+			player:addItem(14222, 1)
+			player:addItem(14097, 1)
+			player:PrintToPlayer(string.format("Obtained the Beast Armor Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.BRD and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(13857, 1)
+			player:addItem(12647, 1)
+			player:addItem(13970, 1)
+			player:addItem(14223, 1)
+			player:addItem(14098, 1)
+			player:PrintToPlayer(string.format("Obtained the Choral Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.RNG and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(12518, 1)
+			player:addItem(12648, 1)
+			player:addItem(13971, 1)
+			player:addItem(14224, 1)
+			player:addItem(14099, 1)
+			player:PrintToPlayer(string.format("Obtained the Hunter's Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.SAM and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(13868, 1)
+			player:addItem(13781, 1)
+			player:addItem(13972, 1)
+			player:addItem(14225, 1)
+			player:addItem(14100, 1)
+			player:PrintToPlayer(string.format("Obtained the Myochin Armor Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.NIN and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(13869, 1)
+			player:addItem(13782, 1)
+			player:addItem(13973, 1)
+			player:addItem(14226, 1)
+			player:addItem(14101, 1)
+			player:PrintToPlayer(string.format("Obtained the Ninja Garb Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.DRG and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(12519, 1)
+			player:addItem(12649, 1)
+			player:addItem(13974, 1)
+			player:addItem(14227, 1)
+			player:addItem(14102, 1)
+			player:PrintToPlayer(string.format("Obtained the Drachen Armor Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.SMN and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(12520, 1)
+			player:addItem(12650, 1)
+			player:addItem(13975, 1)
+			player:addItem(14228, 1)
+			player:addItem(14103, 1)
+			player:PrintToPlayer(string.format("Obtained the Evoker's Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.BLU and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(15265, 1)
+			player:addItem(14521, 1)
+			player:addItem(14928, 1)
+			player:addItem(15600, 1)
+			player:addItem(15684, 1)
+			player:PrintToPlayer(string.format("Obtained the Magus Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.COR and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(15266, 1)
+			player:addItem(14522, 1)
+			player:addItem(14929, 1)
+			player:addItem(15601, 1)
+			player:addItem(15685, 1)
+			player:PrintToPlayer(string.format("Obtained the Corsair's Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.PUP and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(15267, 1)
+			player:addItem(14523, 1)
+			player:addItem(14930, 1)
+			player:addItem(15602, 1)
+			player:addItem(15686, 1)
+			player:PrintToPlayer(string.format("Obtained the Puppetry Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.DNC and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			if (player:getRace() == xi.race.HUME_M or player:getRace() == xi.race.ELVAAN_M or player:getRace() == xi.race.TARU_M or player:getRace() == xi.race.GALKA) then
+				player:addItem(16138, 1)
+				player:addItem(14578, 1)
+				player:addItem(15002, 1)
+				player:addItem(15659, 1)
+				player:addItem(15746, 1)
+				player:PrintToPlayer(string.format("Obtained the Male Dancer's Attire Set!"),xi.msg.channel.SYSTEM_3)
+			else
+				player:addItem(16139, 1)
+				player:addItem(14579, 1)
+				player:addItem(15003, 1)
+				player:addItem(15660, 1)
+				player:addItem(15747, 1)
+				player:PrintToPlayer(string.format("Obtained the Female Dancer's Attire Set!"),xi.msg.channel.SYSTEM_3)
+			end
+		elseif (job == xi.job.SCH and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(16140, 1)
+			player:addItem(14580, 1)
+			player:addItem(15004, 1)
+			player:addItem(16311, 1)
+			player:addItem(15748, 1)
+			player:PrintToPlayer(string.format("Obtained the Scholar's Attire Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.GEO and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(16143, 1, 1, 9, 131, 2) -- +10 MP/+3 MACC/+3 MAB
+			player:addItem(14583, 1, 9, 9, 131, 4) -- +10 HP/+5 MACC/+5 MAB
+			player:addItem(15007, 1, 23, 4, 301, 9) -- +5 ACC/+10 Handbell Skill
+			player:addItem(16314, 1, 112, 2, 300, 9) -- -3% Pet DT/+10 Geomancy Skill
+			player:addItem(15751, 1, 110, 1, 292, 9) -- +2 Pet Regen/+10 Elemental Magic Skill
+			player:PrintToPlayer(string.format("Obtained the GEO augmented Cobra Unit Set!"),xi.msg.channel.SYSTEM_3)
+		elseif (job == xi.job.RUN and level >= 51 and player:getFreeSlotsCount() >= 5) then
+			player:addItem(16143, 1, 513, 1, 23, 4) -- +2 DEX/+5 ACC
+			player:addItem(14583, 1, 514, 2, 17, 9) -- +3 VIT/+10 HP/+10 MP
+			player:addItem(15007, 1, 512, 1, 25, 9) -- +2 STR/+10 ATK
+			player:addItem(16314, 1, 31, 4, 39, 4) -- +5 EVA/+5 Enmity
+			player:addItem(15751, 1, 37, 4, 134, 2) -- +5 MEVA/+3 MDEF
+			player:PrintToPlayer(string.format("Obtained the RUN augmented Cobra Unit Set!"),xi.msg.channel.SYSTEM_3)
+		else
+			player:PrintToPlayer(string.format("Please clear inventory slots and try again!"),xi.msg.channel.SYSTEM_3)
+		end
+	else
+		player:PrintToPlayer(string.format("You can claim a full set of your job's artifact armor from here after level 51."),xi.msg.channel.SYSTEM_3)
+	end
+end)
+
+return m 
+

--- a/modules/custom/lua/caldera_npc_module/Reja_Ygridhi.lua
+++ b/modules/custom/lua/caldera_npc_module/Reja_Ygridhi.lua
@@ -1,0 +1,61 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Reja Ygridhi
+-- Standard Merchant NPC
+-- !pos -110.7740 -2.1500 -103.7501 284
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
+require("modules/module_utils")
+-----------------------------------
+
+local m = Module:new("Reja_Ygridhi")
+
+local npcToReplaceName = "Reja_Ygridhi"
+
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	player:PrintToPlayer(string.format("Reja Ygridhi : Get your storyline mission accessories here!"),xi.msg.channel.NS_SAY)
+    
+	local stock =
+    {
+		15840, 75000,-- Kupofried's Ring
+        14739, 50000,-- Suppanomimi
+		14740, 50000,-- Knight's Earring
+		14741, 50000,-- Abyssal Earring
+        14742, 50000,-- Beastly Earring
+        14743, 50000,-- Bushinomimi
+		15543, 50000,-- Rajas Ring
+		15544, 50000,-- Sattva Ring
+		15545, 50000,-- Tamas Ring
+		15962, 50000,-- Static Earring
+		15963, 50000,-- Magnetic Earring
+		15964, 50000,-- Hollow Earring
+		15965, 50000,-- Ethereal Earring
+		-- 2127, 75000, -- Metal Chip
+		14815, 75000, -- Stealth Earring
+		15961, 75000, -- Musical Earring
+		14812, 75000, -- Loquacious Earring
+		14813, 75000, -- Brutal Earring
+		15477, 75000, -- Boxers Mantle
+		15488, 75000, -- Gunners Mantle
+		15475, 150000, -- Charger Mantle
+		15476, 150000, -- Jaeger Mantle
+		15244, 150000, -- Flawless Ribbon
+		15807, 200000, -- Balrahn's Ring
+		15808, 200000, -- Ulthalam's Ring
+		15809, 200000, -- Jalzahn's Ring
+		11589, 250000, -- Aesir Torque
+		16057, 250000, -- Aesir Ear Pendant
+		11546, 250000, -- Aesir Mantle
+		11590, 250000, -- Colossus's Torque
+		16058, 250000, -- Colossus's Earring
+		11547, 250000, -- Colossus's Mantle
+	}
+
+    xi.shop.general(player, stock)
+end)
+
+return m

--- a/modules/custom/lua/caldera_npc_module/Reja_Ygridhi.lua
+++ b/modules/custom/lua/caldera_npc_module/Reja_Ygridhi.lua
@@ -17,43 +17,43 @@ local npcToReplaceName = "Reja_Ygridhi"
 
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	player:PrintToPlayer(string.format("Reja Ygridhi : Get your storyline mission accessories here!"),xi.msg.channel.NS_SAY)
+    player:PrintToPlayer(string.format("Reja Ygridhi : Get your storyline mission accessories here!"),xi.msg.channel.NS_SAY)
     
-	local stock =
+    local stock =
     {
-		15840, 75000,-- Kupofried's Ring
+        15840, 75000,-- Kupofried's Ring
         14739, 50000,-- Suppanomimi
-		14740, 50000,-- Knight's Earring
-		14741, 50000,-- Abyssal Earring
+        14740, 50000,-- Knight's Earring
+        14741, 50000,-- Abyssal Earring
         14742, 50000,-- Beastly Earring
         14743, 50000,-- Bushinomimi
-		15543, 50000,-- Rajas Ring
-		15544, 50000,-- Sattva Ring
-		15545, 50000,-- Tamas Ring
-		15962, 50000,-- Static Earring
-		15963, 50000,-- Magnetic Earring
-		15964, 50000,-- Hollow Earring
-		15965, 50000,-- Ethereal Earring
-		-- 2127, 75000, -- Metal Chip
-		14815, 75000, -- Stealth Earring
-		15961, 75000, -- Musical Earring
-		14812, 75000, -- Loquacious Earring
-		14813, 75000, -- Brutal Earring
-		15477, 75000, -- Boxers Mantle
-		15488, 75000, -- Gunners Mantle
-		15475, 150000, -- Charger Mantle
-		15476, 150000, -- Jaeger Mantle
-		15244, 150000, -- Flawless Ribbon
-		15807, 200000, -- Balrahn's Ring
-		15808, 200000, -- Ulthalam's Ring
-		15809, 200000, -- Jalzahn's Ring
-		11589, 250000, -- Aesir Torque
-		16057, 250000, -- Aesir Ear Pendant
-		11546, 250000, -- Aesir Mantle
-		11590, 250000, -- Colossus's Torque
-		16058, 250000, -- Colossus's Earring
-		11547, 250000, -- Colossus's Mantle
-	}
+        15543, 50000,-- Rajas Ring
+        15544, 50000,-- Sattva Ring
+        15545, 50000,-- Tamas Ring
+        15962, 50000,-- Static Earring
+        15963, 50000,-- Magnetic Earring
+        15964, 50000,-- Hollow Earring
+        15965, 50000,-- Ethereal Earring
+        -- 2127, 75000, -- Metal Chip
+        14815, 75000, -- Stealth Earring
+        15961, 75000, -- Musical Earring
+        14812, 75000, -- Loquacious Earring
+        14813, 75000, -- Brutal Earring
+        15477, 75000, -- Boxers Mantle
+        15488, 75000, -- Gunners Mantle
+        15475, 150000, -- Charger Mantle
+        15476, 150000, -- Jaeger Mantle
+        15244, 150000, -- Flawless Ribbon
+        15807, 200000, -- Balrahn's Ring
+        15808, 200000, -- Ulthalam's Ring
+        15809, 200000, -- Jalzahn's Ring
+        11589, 250000, -- Aesir Torque
+        16057, 250000, -- Aesir Ear Pendant
+        11546, 250000, -- Aesir Mantle
+        11590, 250000, -- Colossus's Torque
+        16058, 250000, -- Colossus's Earring
+        11547, 250000, -- Colossus's Mantle
+    }
 
     xi.shop.general(player, stock)
 end)

--- a/modules/custom/lua/caldera_npc_module/Trystol.lua
+++ b/modules/custom/lua/caldera_npc_module/Trystol.lua
@@ -1,0 +1,97 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Trystol
+-- !pos -101 -2 -84 284
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
+require("modules/module_utils")
+-----------------------------------
+
+local m = Module:new("Trystol")
+
+local npcToReplaceName = "Trystol"
+
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	local stock_BST = 
+	{
+		-- 17907,	7500,		-- (Ammunition) Swirling Broth
+		-- 21445,	7500,		-- (Ammunition) Lyrical Broth
+		-- 21444,	7500,		-- (Ammunition) Livid Broth
+		-- 21488,	7500,		-- (Ammunition) Pristine Sap
+		-- 21448,	7500,		-- (Ammunition) Pale Sap
+		-- 17908,	7500,		-- (Ammunition) Shimmering Broth
+		-- 21447,	7500,		-- (Ammunition) Crumbly Soil
+		-- 21496,	7500,		-- (Ammunition) Furious Broth
+		-- 21498,	7500,		-- (Ammunition) Crackling Broth
+		-- 21499,	7500,		-- (Ammunition) Creepy Broth
+		-- 21490,	7500,		-- (Ammunition) Aged Humus
+		-- 21497,	7500,		-- (Ammunition) Rapid Broth
+		-- 21449,	7500,		-- (Ammunition) Dire Broth
+		-- 21492,	7500,		-- (Ammunition) Insipid Broth
+		-- 21446,	7500,		-- (Ammunition) Airy Broth
+		-- 17909,	7500,		-- (Ammunition) Spicy Broth
+		-- 21450,	7500,		-- (Ammunition) Electrified Broth
+		-- 21438,	7500,		-- (Ammunition) Poisonous Broth
+		-- 21440,	7500,		-- (Ammunition) Sugary Broth
+		-- 21442,	7500,		-- (Ammunition) Sticky Webbing
+		-- 21494,	7500,		-- (Ammunition) Wetlands Broth
+		-- 17917,  15000,		-- (Ammunition) (HQ) Bubbly Broth
+		-- 21489,	15000,		-- (Ammunition) (HQ) Truly Pristine Sap
+		-- 21493,	15000,		-- (Ammunition) (HQ) Deepwater Broth
+		-- 21451,	15000,		-- (Ammunition) (HQ) Bug-Ridden Broth
+		-- 21439,	15000,		-- (Ammunition) (HQ) Venomous Broth
+		-- 21441,	15000,		-- (Ammunition) (HQ) Glazed Broth
+		-- 21443,	15000,		-- (Ammunition) (HQ) Slimy Webbing
+		-- 21495,	15000,		-- (Ammunition) (HQ) Heavenly Broth
+		21446, 10000,		-- Airy Broth (Amiable Roche)
+		21490, 10000,		-- Aged Humus (Sweet Caroline)
+		17922, 10000,		-- Blackwater Broth (Headbreaker Ken)
+		21498, 10000,		-- Crackling Broth (Anklebiter Jedd)
+		21499, 10000,		-- Creepy Broth (Cursed Annabelle)
+		21447, 10000,		-- Crumbly Soil (Brainy Waluis)
+		21449, 10000,		-- Dire Broth (Generous Arthur)
+		21450, 10000,		-- Electrified Broth (Redolent Candi)
+		17912, 10000,		-- Fizzy Broth (Caring Kiyomaro)
+		21496, 10000,		-- Furious Broth (Suspicious Alice)
+		21492, 10000,		-- Insipid Broth (Surging Storm)
+		21444, 10000,		-- Livid Broth (Warlike Patrick)
+		21445, 10000,		-- Lyrical Broth (Rhyming Shizuna)
+		17920, 10000,		-- Meaty Broth (Blackbeard Randy)
+		17921, 10000,		-- Muddy Broth (Threestar Lynn)
+		21448, 10000,		-- Pale Sap (Hurler Percival)
+		21438, 10000,		-- Poisonous Broth (Acuex Familiar)
+		21488, 10000,		-- Pristine Sap (Weevil Familiar)
+		21497, 10000,		-- Rapid Broth (Fleet Reinhard)
+		17913, 10000,		-- Saline Broth (Sharpwit Hermes)
+		17911, 10000,		-- Salubrious Broth (Attentive Ibuki)
+		17908, 10000,		-- Shimmering Broth (Sunburst Malfik)
+		17909, 10000,		-- Spicy Broth (Scissorleg Xerin)
+		21442, 10000,		-- Sticky Webbing (Spider Familiar)
+		21440, 10000,		-- Sugary Broth (Colibri Familiar)
+		17907, 10000,		-- Swirling Broth (Droopy Dortwin)
+		17910, 10000,		-- Transluscent Broth (Herald Henry)
+		21494, 10000,		-- Wetlands Broth (Mosquito Familiar)
+		17914, 10000,		-- Wispy Broth (Brave Hero Glenn)
+		21451, 15000,		-- Bug-Ridden Broth (Alluring Honey)
+		17919, 15000,		-- Tantalizing Broth (Vivacious Vickie)
+		21493, 15000,		-- Deepwater Broth (Submerged Iyo)
+		21439, 15000,		-- Venomous Broth (Fluffy Bredo)
+		21489, 15000,		-- Truly Pristine Sap (Stalwart Angelina)
+		17918, 15000,		-- Windy Greens (Swooping Zhivago)
+		17916, 15000,		-- Fermented Broth (Aged Angus)
+		17917, 15000,		-- Bubbly Broth (Bouncing Bertha)
+		21443, 15000,		-- Slimy Webbing (Gussy Hachirobe)
+		21441, 15000,		-- Glazed Broth (Choral Leera)
+		17915, 15000,		-- Viscous Broth (Pondering Peter)
+		21495, 15000,		-- Heavenly Broth (Left-Handed Yoko)
+	}
+	xi.shop.general(player, stock_BST)
+	
+	player:PrintToPlayer(string.format("Trystol : I have all of the foods for attracting the best pets a Beastmaster could ask for!"),xi.msg.channel.NS_SAY)
+end)
+
+return m

--- a/modules/custom/lua/caldera_npc_module/Trystol.lua
+++ b/modules/custom/lua/caldera_npc_module/Trystol.lua
@@ -16,82 +16,82 @@ local npcToReplaceName = "Trystol"
 
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	local stock_BST = 
-	{
-		-- 17907,	7500,		-- (Ammunition) Swirling Broth
-		-- 21445,	7500,		-- (Ammunition) Lyrical Broth
-		-- 21444,	7500,		-- (Ammunition) Livid Broth
-		-- 21488,	7500,		-- (Ammunition) Pristine Sap
-		-- 21448,	7500,		-- (Ammunition) Pale Sap
-		-- 17908,	7500,		-- (Ammunition) Shimmering Broth
-		-- 21447,	7500,		-- (Ammunition) Crumbly Soil
-		-- 21496,	7500,		-- (Ammunition) Furious Broth
-		-- 21498,	7500,		-- (Ammunition) Crackling Broth
-		-- 21499,	7500,		-- (Ammunition) Creepy Broth
-		-- 21490,	7500,		-- (Ammunition) Aged Humus
-		-- 21497,	7500,		-- (Ammunition) Rapid Broth
-		-- 21449,	7500,		-- (Ammunition) Dire Broth
-		-- 21492,	7500,		-- (Ammunition) Insipid Broth
-		-- 21446,	7500,		-- (Ammunition) Airy Broth
-		-- 17909,	7500,		-- (Ammunition) Spicy Broth
-		-- 21450,	7500,		-- (Ammunition) Electrified Broth
-		-- 21438,	7500,		-- (Ammunition) Poisonous Broth
-		-- 21440,	7500,		-- (Ammunition) Sugary Broth
-		-- 21442,	7500,		-- (Ammunition) Sticky Webbing
-		-- 21494,	7500,		-- (Ammunition) Wetlands Broth
-		-- 17917,  15000,		-- (Ammunition) (HQ) Bubbly Broth
-		-- 21489,	15000,		-- (Ammunition) (HQ) Truly Pristine Sap
-		-- 21493,	15000,		-- (Ammunition) (HQ) Deepwater Broth
-		-- 21451,	15000,		-- (Ammunition) (HQ) Bug-Ridden Broth
-		-- 21439,	15000,		-- (Ammunition) (HQ) Venomous Broth
-		-- 21441,	15000,		-- (Ammunition) (HQ) Glazed Broth
-		-- 21443,	15000,		-- (Ammunition) (HQ) Slimy Webbing
-		-- 21495,	15000,		-- (Ammunition) (HQ) Heavenly Broth
-		21446, 10000,		-- Airy Broth (Amiable Roche)
-		21490, 10000,		-- Aged Humus (Sweet Caroline)
-		17922, 10000,		-- Blackwater Broth (Headbreaker Ken)
-		21498, 10000,		-- Crackling Broth (Anklebiter Jedd)
-		21499, 10000,		-- Creepy Broth (Cursed Annabelle)
-		21447, 10000,		-- Crumbly Soil (Brainy Waluis)
-		21449, 10000,		-- Dire Broth (Generous Arthur)
-		21450, 10000,		-- Electrified Broth (Redolent Candi)
-		17912, 10000,		-- Fizzy Broth (Caring Kiyomaro)
-		21496, 10000,		-- Furious Broth (Suspicious Alice)
-		21492, 10000,		-- Insipid Broth (Surging Storm)
-		21444, 10000,		-- Livid Broth (Warlike Patrick)
-		21445, 10000,		-- Lyrical Broth (Rhyming Shizuna)
-		17920, 10000,		-- Meaty Broth (Blackbeard Randy)
-		17921, 10000,		-- Muddy Broth (Threestar Lynn)
-		21448, 10000,		-- Pale Sap (Hurler Percival)
-		21438, 10000,		-- Poisonous Broth (Acuex Familiar)
-		21488, 10000,		-- Pristine Sap (Weevil Familiar)
-		21497, 10000,		-- Rapid Broth (Fleet Reinhard)
-		17913, 10000,		-- Saline Broth (Sharpwit Hermes)
-		17911, 10000,		-- Salubrious Broth (Attentive Ibuki)
-		17908, 10000,		-- Shimmering Broth (Sunburst Malfik)
-		17909, 10000,		-- Spicy Broth (Scissorleg Xerin)
-		21442, 10000,		-- Sticky Webbing (Spider Familiar)
-		21440, 10000,		-- Sugary Broth (Colibri Familiar)
-		17907, 10000,		-- Swirling Broth (Droopy Dortwin)
-		17910, 10000,		-- Transluscent Broth (Herald Henry)
-		21494, 10000,		-- Wetlands Broth (Mosquito Familiar)
-		17914, 10000,		-- Wispy Broth (Brave Hero Glenn)
-		21451, 15000,		-- Bug-Ridden Broth (Alluring Honey)
-		17919, 15000,		-- Tantalizing Broth (Vivacious Vickie)
-		21493, 15000,		-- Deepwater Broth (Submerged Iyo)
-		21439, 15000,		-- Venomous Broth (Fluffy Bredo)
-		21489, 15000,		-- Truly Pristine Sap (Stalwart Angelina)
-		17918, 15000,		-- Windy Greens (Swooping Zhivago)
-		17916, 15000,		-- Fermented Broth (Aged Angus)
-		17917, 15000,		-- Bubbly Broth (Bouncing Bertha)
-		21443, 15000,		-- Slimy Webbing (Gussy Hachirobe)
-		21441, 15000,		-- Glazed Broth (Choral Leera)
-		17915, 15000,		-- Viscous Broth (Pondering Peter)
-		21495, 15000,		-- Heavenly Broth (Left-Handed Yoko)
-	}
-	xi.shop.general(player, stock_BST)
-	
-	player:PrintToPlayer(string.format("Trystol : I have all of the foods for attracting the best pets a Beastmaster could ask for!"),xi.msg.channel.NS_SAY)
+    local stock_BST = 
+    {
+        -- 17907,   7500,       -- (Ammunition) Swirling Broth
+        -- 21445,   7500,       -- (Ammunition) Lyrical Broth
+        -- 21444,   7500,       -- (Ammunition) Livid Broth
+        -- 21488,   7500,       -- (Ammunition) Pristine Sap
+        -- 21448,   7500,       -- (Ammunition) Pale Sap
+        -- 17908,   7500,       -- (Ammunition) Shimmering Broth
+        -- 21447,   7500,       -- (Ammunition) Crumbly Soil
+        -- 21496,   7500,       -- (Ammunition) Furious Broth
+        -- 21498,   7500,       -- (Ammunition) Crackling Broth
+        -- 21499,   7500,       -- (Ammunition) Creepy Broth
+        -- 21490,   7500,       -- (Ammunition) Aged Humus
+        -- 21497,   7500,       -- (Ammunition) Rapid Broth
+        -- 21449,   7500,       -- (Ammunition) Dire Broth
+        -- 21492,   7500,       -- (Ammunition) Insipid Broth
+        -- 21446,   7500,       -- (Ammunition) Airy Broth
+        -- 17909,   7500,       -- (Ammunition) Spicy Broth
+        -- 21450,   7500,       -- (Ammunition) Electrified Broth
+        -- 21438,   7500,       -- (Ammunition) Poisonous Broth
+        -- 21440,   7500,       -- (Ammunition) Sugary Broth
+        -- 21442,   7500,       -- (Ammunition) Sticky Webbing
+        -- 21494,   7500,       -- (Ammunition) Wetlands Broth
+        -- 17917,  15000,       -- (Ammunition) (HQ) Bubbly Broth
+        -- 21489,   15000,      -- (Ammunition) (HQ) Truly Pristine Sap
+        -- 21493,   15000,      -- (Ammunition) (HQ) Deepwater Broth
+        -- 21451,   15000,      -- (Ammunition) (HQ) Bug-Ridden Broth
+        -- 21439,   15000,      -- (Ammunition) (HQ) Venomous Broth
+        -- 21441,   15000,      -- (Ammunition) (HQ) Glazed Broth
+        -- 21443,   15000,      -- (Ammunition) (HQ) Slimy Webbing
+        -- 21495,   15000,      -- (Ammunition) (HQ) Heavenly Broth
+        21446, 10000,       -- Airy Broth (Amiable Roche)
+        21490, 10000,       -- Aged Humus (Sweet Caroline)
+        17922, 10000,       -- Blackwater Broth (Headbreaker Ken)
+        21498, 10000,       -- Crackling Broth (Anklebiter Jedd)
+        21499, 10000,       -- Creepy Broth (Cursed Annabelle)
+        21447, 10000,       -- Crumbly Soil (Brainy Waluis)
+        21449, 10000,       -- Dire Broth (Generous Arthur)
+        21450, 10000,       -- Electrified Broth (Redolent Candi)
+        17912, 10000,       -- Fizzy Broth (Caring Kiyomaro)
+        21496, 10000,       -- Furious Broth (Suspicious Alice)
+        21492, 10000,       -- Insipid Broth (Surging Storm)
+        21444, 10000,       -- Livid Broth (Warlike Patrick)
+        21445, 10000,       -- Lyrical Broth (Rhyming Shizuna)
+        17920, 10000,       -- Meaty Broth (Blackbeard Randy)
+        17921, 10000,       -- Muddy Broth (Threestar Lynn)
+        21448, 10000,       -- Pale Sap (Hurler Percival)
+        21438, 10000,       -- Poisonous Broth (Acuex Familiar)
+        21488, 10000,       -- Pristine Sap (Weevil Familiar)
+        21497, 10000,       -- Rapid Broth (Fleet Reinhard)
+        17913, 10000,       -- Saline Broth (Sharpwit Hermes)
+        17911, 10000,       -- Salubrious Broth (Attentive Ibuki)
+        17908, 10000,       -- Shimmering Broth (Sunburst Malfik)
+        17909, 10000,       -- Spicy Broth (Scissorleg Xerin)
+        21442, 10000,       -- Sticky Webbing (Spider Familiar)
+        21440, 10000,       -- Sugary Broth (Colibri Familiar)
+        17907, 10000,       -- Swirling Broth (Droopy Dortwin)
+        17910, 10000,       -- Transluscent Broth (Herald Henry)
+        21494, 10000,       -- Wetlands Broth (Mosquito Familiar)
+        17914, 10000,       -- Wispy Broth (Brave Hero Glenn)
+        21451, 15000,       -- Bug-Ridden Broth (Alluring Honey)
+        17919, 15000,       -- Tantalizing Broth (Vivacious Vickie)
+        21493, 15000,       -- Deepwater Broth (Submerged Iyo)
+        21439, 15000,       -- Venomous Broth (Fluffy Bredo)
+        21489, 15000,       -- Truly Pristine Sap (Stalwart Angelina)
+        17918, 15000,       -- Windy Greens (Swooping Zhivago)
+        17916, 15000,       -- Fermented Broth (Aged Angus)
+        17917, 15000,       -- Bubbly Broth (Bouncing Bertha)
+        21443, 15000,       -- Slimy Webbing (Gussy Hachirobe)
+        21441, 15000,       -- Glazed Broth (Choral Leera)
+        17915, 15000,       -- Viscous Broth (Pondering Peter)
+        21495, 15000,       -- Heavenly Broth (Left-Handed Yoko)
+    }
+    xi.shop.general(player, stock_BST)
+    
+    player:PrintToPlayer(string.format("Trystol : I have all of the foods for attracting the best pets a Beastmaster could ask for!"),xi.msg.channel.NS_SAY)
 end)
 
 return m

--- a/modules/custom/lua/caldera_npc_module/Vainrachault.lua
+++ b/modules/custom/lua/caldera_npc_module/Vainrachault.lua
@@ -15,232 +15,232 @@ local m = Module:new("Vainrachault")
 local npcToReplaceName = "Vainrachault"
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
-	local stock_under_99 = 
-	{
-		5402, 7500,			-- (Ammunition) Fire Card Case
-		5403, 7500,			-- (Ammunition) Ice Card Case
-		5404, 7500,			-- (Ammunition) Wind Card Case
-		5405, 7500,			-- (Ammunition) Earth Card Case
-		5406, 7500,			-- (Ammunition) Thunder Card Case
-		5407, 7500,			-- (Ammunition) Water Card Case
-		5408, 7500,			-- (Ammunition) Light Card Case
-		5409, 7500,			-- (Ammunition) Dark Card Case
-		5870, 12500,		-- (Ammunition) Trump Card Case
-		17296,	1,			-- (Throwing) Pebble
-		17298,	20,			-- (Ammunition) Tathlum
-		17299,	50,			-- (Ammunition) Astragalos
-		17290,	5000,		-- (Throwing) Coarse Boomerang
-		6299,	500,		-- (Throwing) Shuriken Pouch
-		6297,	2000,		-- (Throwing) Juji Shuriken Pouch
-		6302,	5000,		-- (Throwing) Fuma Shuriken Pouch
-		6300,	7500,		-- (Throwing) Koga Shuriken Pouch
-		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
-		4219,	200,		-- (Ammunition) Stone Arrow Quiver
-		4222,	2000,		-- (Ammunition) Horn Arrow Quiver
-		4224,	5000,		-- (Ammunition) Demon Arrow Quiver
-		5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
-		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
-		4227,	200,		-- (Ammunition) Bronze Bolt Quiver
-		4228,	2000,		-- (Ammunition) Mythril Bolt Quiver
-		4229,	5000,		-- (Ammunition) Darksteel Bolt Quiver
-		5821,	7500,		-- (Ammunition) Fusion Bolt Quiver
-		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
-		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
-		5359,	200,		-- (Ammunition) Bronze Bullet Pouch
-		5363,	2000,		-- (Ammunition) Bullet Pouch
-		5353,	5000,		-- (Ammunition) Iron Bullet Pouch
-		17342,	75,			-- (Ammunition) Cannon Shell
-		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
-		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
-	}
-	
-	local stock_over_99_basic = 
-	{
-		5402, 7500,			-- (Ammunition) Fire Card Case
-		5403, 7500,			-- (Ammunition) Ice Card Case
-		5404, 7500,			-- (Ammunition) Wind Card Case
-		5405, 7500,			-- (Ammunition) Earth Card Case
-		5406, 7500,			-- (Ammunition) Thunder Card Case
-		5407, 7500,			-- (Ammunition) Water Card Case
-		5408, 7500,			-- (Ammunition) Light Card Case
-		5409, 7500,			-- (Ammunition) Dark Card Case
-		5870, 12500,		-- (Ammunition) Trump Card Case
-		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
-		5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
-		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
-		6138,	35000,		-- (Ammunition) Mantid Arrow Quiver
-		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
-		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
-		6140,	35000,		-- (Ammunition) Damascus Bolt Quiver
-		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
-		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
-		6143,	35000,		-- (Ammunition) Damascus Bullet Pouch
-	}
-	
-	local stock_t1_locked = 
-	{
-		5402, 7500,			-- (Ammunition) Fire Card Case
-		5403, 7500,			-- (Ammunition) Ice Card Case
-		5404, 7500,			-- (Ammunition) Wind Card Case
-		5405, 7500,			-- (Ammunition) Earth Card Case
-		5406, 7500,			-- (Ammunition) Thunder Card Case
-		5407, 7500,			-- (Ammunition) Water Card Case
-		5408, 7500,			-- (Ammunition) Light Card Case
-		5409, 7500,			-- (Ammunition) Dark Card Case
-		5870, 12500,		-- (Ammunition) Trump Card Case
-		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
-		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
-		6138,	35000,		-- (Ammunition) Mantid Arrow Quiver
-		6201,	50000,		-- (Ammunition) Tulfaire Arrow Quiver
-		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
-		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
-		6140,	35000,		-- (Ammunition) Damascus Bolt Quiver
-		6205,	50000,		-- (Ammunition) Titanium Bolt Quiver
-		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
-		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
-		6143,	35000,		-- (Ammunition) Damascus Bullet Pouch
-		6209,	50000,		-- (Ammunition) Titanium Bullet Pouch
-	}
-	
-	local stock_t2_locked = 
-	{
-		5402, 7500,			-- (Ammunition) Fire Card Case
-		5403, 7500,			-- (Ammunition) Ice Card Case
-		5404, 7500,			-- (Ammunition) Wind Card Case
-		5405, 7500,			-- (Ammunition) Earth Card Case
-		5406, 7500,			-- (Ammunition) Thunder Card Case
-		5407, 7500,			-- (Ammunition) Water Card Case
-		5408, 7500,			-- (Ammunition) Light Card Case
-		5409, 7500,			-- (Ammunition) Dark Card Case
-		5870, 12500,		-- (Ammunition) Trump Card Case
-		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
-		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
-		6138,	35000,		-- (Ammunition) Mantid Arrow Quiver
-		6201,	50000,		-- (Ammunition) Tulfaire Arrow Quiver
-		6202,	70000,		-- (Ammunition) Raaz Arrow Quiver
-		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
-		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
-		6140,	35000,		-- (Ammunition) Damascus Bolt Quiver
-		6205,	50000,		-- (Ammunition) Titanium Bolt Quiver
-		6206,	70000,		-- (Ammunition) Bismuth Bolt Quiver
-		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
-		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
-		6143,	35000,		-- (Ammunition) Damascus Bullet Pouch
-		6209,	50000,		-- (Ammunition) Titanium Bullet Pouch
-		6210,	70000,		-- (Ammunition) Bismuth Bullet Pouch
-	}
-	
-	local stock_t3_locked = 
-	{
-		5402, 7500,			-- (Ammunition) Fire Card Case
-		5403, 7500,			-- (Ammunition) Ice Card Case
-		5404, 7500,			-- (Ammunition) Wind Card Case
-		5405, 7500,			-- (Ammunition) Earth Card Case
-		5406, 7500,			-- (Ammunition) Thunder Card Case
-		5407, 7500,			-- (Ammunition) Water Card Case
-		5408, 7500,			-- (Ammunition) Light Card Case
-		5409, 7500,			-- (Ammunition) Dark Card Case
-		5870, 12500,		-- (Ammunition) Trump Card Case
-		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
-		6308,	30000,		-- (Throwing) Hachiya Shuriken Pouch
-		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
-		6138,	35000,		-- (Ammunition) Mantid Arrow Quiver
-		6201,	50000,		-- (Ammunition) Tulfaire Arrow Quiver
-		6202,	70000,		-- (Ammunition) Raaz Arrow Quiver
-		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
-		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
-		6140,	35000,		-- (Ammunition) Damascus Bolt Quiver
-		6205,	50000,		-- (Ammunition) Titanium Bolt Quiver
-		6206,	70000,		-- (Ammunition) Bismuth Bolt Quiver
-		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
-		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
-		6143,	35000,		-- (Ammunition) Damascus Bullet Pouch
-		6209,	50000,		-- (Ammunition) Titanium Bullet Pouch
-		6210,	70000,		-- (Ammunition) Bismuth Bullet Pouch
-	}
-	
-	local stock_t4_locked = 
-	{
-		5402, 7500,			-- (Ammunition) Fire Card Case
-		5403, 7500,			-- (Ammunition) Ice Card Case
-		5404, 7500,			-- (Ammunition) Wind Card Case
-		5405, 7500,			-- (Ammunition) Earth Card Case
-		5406, 7500,			-- (Ammunition) Thunder Card Case
-		5407, 7500,			-- (Ammunition) Water Card Case
-		5408, 7500,			-- (Ammunition) Light Card Case
-		5409, 7500,			-- (Ammunition) Dark Card Case
-		5870, 12500,		-- (Ammunition) Trump Card Case
-		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
-		6308,	30000,		-- (Throwing) Hachiya Shuriken Pouch
-		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
-		6138,	35000,		-- (Ammunition) Mantid Arrow Quiver
-		6201,	50000,		-- (Ammunition) Tulfaire Arrow Quiver
-		6202,	70000,		-- (Ammunition) Raaz Arrow Quiver
-		6280,	90000,		-- (Ammunition) Ra'Kaznar Arrow Quiver
-		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
-		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
-		6140,	35000,		-- (Ammunition) Damascus Bolt Quiver
-		6205,	50000,		-- (Ammunition) Titanium Bolt Quiver
-		6206,	70000,		-- (Ammunition) Bismuth Bolt Quiver
-		6281,	90000,		-- (Ammunition) Ra'Kaznar Bolt Quiver
-		6310,	90000,		-- (Ammunition) Gashing Bolt Quiver
-		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
-		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
-		6143,	35000,		-- (Ammunition) Damascus Bullet Pouch
-		6209,	50000,		-- (Ammunition) Titanium Bullet Pouch
-		6210,	70000,		-- (Ammunition) Bismuth Bullet Pouch
-		6282,	90000,		-- (Ammunition) Ra'Kaznar Bullet Pouch
-	}
-	
-	local playerLvl = player:getMainLvl() + player:getAverageItemLevel()
-	local t1Unlock = 0
-	local t2Unlock = 0
-	local t3Unlock = 0
-	local t4Unlock = 0
-	
-	if (player:getCharVar("KillCounter_Byakko") >= 1 and player:getCharVar("KillCounter_Genbu") >= 1 and
-		player:getCharVar("KillCounter_Seiryu") >= 1 and player:getCharVar("KillCounter_Suzaku") >= 1) then
-		t1Unlock = 1
-		-- printf("Vainrachault.lua onTrigger TIER 3 UNLOCKED  [%i]", t1Unlock)
-	end
-	
-	if (player:getCharVar("KillCounter_IxAernDRG") >= 1 and player:getCharVar("KillCounter_IxAernDRK") >= 1 and player:getCharVar("KillCounter_IxAernMNK") >= 1 and
-		player:getCharVar("KillCounter_JailOfFaith") >= 1 and player:getCharVar("KillCounter_JailOfFort") >= 1 and player:getCharVar("KillCounter_JailOfTemp") >= 1) then
-		t2Unlock = 1
-		-- printf("Vainrachault.lua onTrigger TIER 4 UNLOCKED")
-	end
-	
-	if (player:getCharVar("KillCounter_Kirin") >= 1 and player:getCharVar("KillCounter_JailOfLove") >= 1) then
-		t3Unlock = 1
-		-- printf("Vainrachault.lua onTrigger TIER 5 UNLOCKED")
-	end
-	
-	if (player:getCharVar("KillCounter_ShadowLord") >= 1 and player:getCharVar("KillCounter_Kamlanaut") >= 1) then
-		t4Unlock = 1
-		-- printf("Vainrachault.lua onTrigger TIER 6 UNLOCKED")
-	end
-	
-	if (playerLvl >= 99 and t1Unlock == 1 and t2Unlock == 1 and t3Unlock == 1 and t4Unlock == 1) then
-		xi.shop.general(player, stock_t4_locked)
-		-- printf("Vainrachault.lua onTrigger TIER 6 SHOP")
-	elseif (playerLvl >= 99 and t1Unlock == 1 and t2Unlock == 1 and t3Unlock == 1) then
-		xi.shop.general(player, stock_t3_locked)
-		-- printf("Vainrachault.lua onTrigger TIER 5 SHOP")
-	elseif (playerLvl >= 99 and t1Unlock == 1 and t2Unlock == 1) then
-		xi.shop.general(player, stock_t2_locked)
-		-- printf("Vainrachault.lua onTrigger TIER 4 SHOP")
-	elseif (playerLvl >= 99 and t1Unlock == 1) then
-		xi.shop.general(player, stock_t1_locked)
-		-- printf("Vainrachault.lua onTrigger TIER 3 SHOP")
-	elseif (playerLvl >= 99) then
-		xi.shop.general(player, stock_over_99_basic)
-		-- printf("Vainrachault.lua onTrigger TIER 2 SHOP")
-	else
-		xi.shop.general(player, stock_under_99)
-		-- printf("Vainrachault.lua onTrigger TIER 1 SHOP")
-	end
-	
-	player:PrintToPlayer(string.format("Vainrachault : Looking for ranged ammunition? I have a wide variety available for sale!"),xi.msg.channel.NS_SAY)
+    local stock_under_99 = 
+    {
+        5402, 7500,         -- (Ammunition) Fire Card Case
+        5403, 7500,         -- (Ammunition) Ice Card Case
+        5404, 7500,         -- (Ammunition) Wind Card Case
+        5405, 7500,         -- (Ammunition) Earth Card Case
+        5406, 7500,         -- (Ammunition) Thunder Card Case
+        5407, 7500,         -- (Ammunition) Water Card Case
+        5408, 7500,         -- (Ammunition) Light Card Case
+        5409, 7500,         -- (Ammunition) Dark Card Case
+        5870, 12500,        -- (Ammunition) Trump Card Case
+        17296,  1,          -- (Throwing) Pebble
+        17298,  20,         -- (Ammunition) Tathlum
+        17299,  50,         -- (Ammunition) Astragalos
+        17290,  5000,       -- (Throwing) Coarse Boomerang
+        6299,   500,        -- (Throwing) Shuriken Pouch
+        6297,   2000,       -- (Throwing) Juji Shuriken Pouch
+        6302,   5000,       -- (Throwing) Fuma Shuriken Pouch
+        6300,   7500,       -- (Throwing) Koga Shuriken Pouch
+        6304,   12000,      -- (Throwing) Roppo Shuriken Pouch
+        4219,   200,        -- (Ammunition) Stone Arrow Quiver
+        4222,   2000,       -- (Ammunition) Horn Arrow Quiver
+        4224,   5000,       -- (Ammunition) Demon Arrow Quiver
+        5819,   7500,       -- (Ammunition) Antlion Arrow Quiver
+        6137,   11500,      -- (Ammunition) Chapuli Arrow Quiver
+        4227,   200,        -- (Ammunition) Bronze Bolt Quiver
+        4228,   2000,       -- (Ammunition) Mythril Bolt Quiver
+        4229,   5000,       -- (Ammunition) Darksteel Bolt Quiver
+        5821,   7500,       -- (Ammunition) Fusion Bolt Quiver
+        6141,   11500,      -- (Ammunition) Oxidant Bolt Quiver
+        6139,   11500,      -- (Ammunition) Midrium Bolt Quiver
+        5359,   200,        -- (Ammunition) Bronze Bullet Pouch
+        5363,   2000,       -- (Ammunition) Bullet Pouch
+        5353,   5000,       -- (Ammunition) Iron Bullet Pouch
+        17342,  75,         -- (Ammunition) Cannon Shell
+        5823,   7500,       -- (Ammunition) Oberon's Bullet Pouch
+        6142,   11500,      -- (Ammunition) Midrium Bullet Pouch
+    }
+    
+    local stock_over_99_basic = 
+    {
+        5402, 7500,         -- (Ammunition) Fire Card Case
+        5403, 7500,         -- (Ammunition) Ice Card Case
+        5404, 7500,         -- (Ammunition) Wind Card Case
+        5405, 7500,         -- (Ammunition) Earth Card Case
+        5406, 7500,         -- (Ammunition) Thunder Card Case
+        5407, 7500,         -- (Ammunition) Water Card Case
+        5408, 7500,         -- (Ammunition) Light Card Case
+        5409, 7500,         -- (Ammunition) Dark Card Case
+        5870, 12500,        -- (Ammunition) Trump Card Case
+        6304,   12000,      -- (Throwing) Roppo Shuriken Pouch
+        5819,   7500,       -- (Ammunition) Antlion Arrow Quiver
+        6137,   11500,      -- (Ammunition) Chapuli Arrow Quiver
+        6138,   35000,      -- (Ammunition) Mantid Arrow Quiver
+        6141,   11500,      -- (Ammunition) Oxidant Bolt Quiver
+        6139,   11500,      -- (Ammunition) Midrium Bolt Quiver
+        6140,   35000,      -- (Ammunition) Damascus Bolt Quiver
+        5823,   7500,       -- (Ammunition) Oberon's Bullet Pouch
+        6142,   11500,      -- (Ammunition) Midrium Bullet Pouch
+        6143,   35000,      -- (Ammunition) Damascus Bullet Pouch
+    }
+    
+    local stock_t1_locked = 
+    {
+        5402, 7500,         -- (Ammunition) Fire Card Case
+        5403, 7500,         -- (Ammunition) Ice Card Case
+        5404, 7500,         -- (Ammunition) Wind Card Case
+        5405, 7500,         -- (Ammunition) Earth Card Case
+        5406, 7500,         -- (Ammunition) Thunder Card Case
+        5407, 7500,         -- (Ammunition) Water Card Case
+        5408, 7500,         -- (Ammunition) Light Card Case
+        5409, 7500,         -- (Ammunition) Dark Card Case
+        5870, 12500,        -- (Ammunition) Trump Card Case
+        6304,   12000,      -- (Throwing) Roppo Shuriken Pouch
+        6137,   11500,      -- (Ammunition) Chapuli Arrow Quiver
+        6138,   35000,      -- (Ammunition) Mantid Arrow Quiver
+        6201,   50000,      -- (Ammunition) Tulfaire Arrow Quiver
+        6141,   11500,      -- (Ammunition) Oxidant Bolt Quiver
+        6139,   11500,      -- (Ammunition) Midrium Bolt Quiver
+        6140,   35000,      -- (Ammunition) Damascus Bolt Quiver
+        6205,   50000,      -- (Ammunition) Titanium Bolt Quiver
+        5823,   7500,       -- (Ammunition) Oberon's Bullet Pouch
+        6142,   11500,      -- (Ammunition) Midrium Bullet Pouch
+        6143,   35000,      -- (Ammunition) Damascus Bullet Pouch
+        6209,   50000,      -- (Ammunition) Titanium Bullet Pouch
+    }
+    
+    local stock_t2_locked = 
+    {
+        5402, 7500,         -- (Ammunition) Fire Card Case
+        5403, 7500,         -- (Ammunition) Ice Card Case
+        5404, 7500,         -- (Ammunition) Wind Card Case
+        5405, 7500,         -- (Ammunition) Earth Card Case
+        5406, 7500,         -- (Ammunition) Thunder Card Case
+        5407, 7500,         -- (Ammunition) Water Card Case
+        5408, 7500,         -- (Ammunition) Light Card Case
+        5409, 7500,         -- (Ammunition) Dark Card Case
+        5870, 12500,        -- (Ammunition) Trump Card Case
+        6304,   12000,      -- (Throwing) Roppo Shuriken Pouch
+        6137,   11500,      -- (Ammunition) Chapuli Arrow Quiver
+        6138,   35000,      -- (Ammunition) Mantid Arrow Quiver
+        6201,   50000,      -- (Ammunition) Tulfaire Arrow Quiver
+        6202,   70000,      -- (Ammunition) Raaz Arrow Quiver
+        6141,   11500,      -- (Ammunition) Oxidant Bolt Quiver
+        6139,   11500,      -- (Ammunition) Midrium Bolt Quiver
+        6140,   35000,      -- (Ammunition) Damascus Bolt Quiver
+        6205,   50000,      -- (Ammunition) Titanium Bolt Quiver
+        6206,   70000,      -- (Ammunition) Bismuth Bolt Quiver
+        5823,   7500,       -- (Ammunition) Oberon's Bullet Pouch
+        6142,   11500,      -- (Ammunition) Midrium Bullet Pouch
+        6143,   35000,      -- (Ammunition) Damascus Bullet Pouch
+        6209,   50000,      -- (Ammunition) Titanium Bullet Pouch
+        6210,   70000,      -- (Ammunition) Bismuth Bullet Pouch
+    }
+    
+    local stock_t3_locked = 
+    {
+        5402, 7500,         -- (Ammunition) Fire Card Case
+        5403, 7500,         -- (Ammunition) Ice Card Case
+        5404, 7500,         -- (Ammunition) Wind Card Case
+        5405, 7500,         -- (Ammunition) Earth Card Case
+        5406, 7500,         -- (Ammunition) Thunder Card Case
+        5407, 7500,         -- (Ammunition) Water Card Case
+        5408, 7500,         -- (Ammunition) Light Card Case
+        5409, 7500,         -- (Ammunition) Dark Card Case
+        5870, 12500,        -- (Ammunition) Trump Card Case
+        6304,   12000,      -- (Throwing) Roppo Shuriken Pouch
+        6308,   30000,      -- (Throwing) Hachiya Shuriken Pouch
+        6137,   11500,      -- (Ammunition) Chapuli Arrow Quiver
+        6138,   35000,      -- (Ammunition) Mantid Arrow Quiver
+        6201,   50000,      -- (Ammunition) Tulfaire Arrow Quiver
+        6202,   70000,      -- (Ammunition) Raaz Arrow Quiver
+        6141,   11500,      -- (Ammunition) Oxidant Bolt Quiver
+        6139,   11500,      -- (Ammunition) Midrium Bolt Quiver
+        6140,   35000,      -- (Ammunition) Damascus Bolt Quiver
+        6205,   50000,      -- (Ammunition) Titanium Bolt Quiver
+        6206,   70000,      -- (Ammunition) Bismuth Bolt Quiver
+        5823,   7500,       -- (Ammunition) Oberon's Bullet Pouch
+        6142,   11500,      -- (Ammunition) Midrium Bullet Pouch
+        6143,   35000,      -- (Ammunition) Damascus Bullet Pouch
+        6209,   50000,      -- (Ammunition) Titanium Bullet Pouch
+        6210,   70000,      -- (Ammunition) Bismuth Bullet Pouch
+    }
+    
+    local stock_t4_locked = 
+    {
+        5402, 7500,         -- (Ammunition) Fire Card Case
+        5403, 7500,         -- (Ammunition) Ice Card Case
+        5404, 7500,         -- (Ammunition) Wind Card Case
+        5405, 7500,         -- (Ammunition) Earth Card Case
+        5406, 7500,         -- (Ammunition) Thunder Card Case
+        5407, 7500,         -- (Ammunition) Water Card Case
+        5408, 7500,         -- (Ammunition) Light Card Case
+        5409, 7500,         -- (Ammunition) Dark Card Case
+        5870, 12500,        -- (Ammunition) Trump Card Case
+        6304,   12000,      -- (Throwing) Roppo Shuriken Pouch
+        6308,   30000,      -- (Throwing) Hachiya Shuriken Pouch
+        6137,   11500,      -- (Ammunition) Chapuli Arrow Quiver
+        6138,   35000,      -- (Ammunition) Mantid Arrow Quiver
+        6201,   50000,      -- (Ammunition) Tulfaire Arrow Quiver
+        6202,   70000,      -- (Ammunition) Raaz Arrow Quiver
+        6280,   90000,      -- (Ammunition) Ra'Kaznar Arrow Quiver
+        6141,   11500,      -- (Ammunition) Oxidant Bolt Quiver
+        6139,   11500,      -- (Ammunition) Midrium Bolt Quiver
+        6140,   35000,      -- (Ammunition) Damascus Bolt Quiver
+        6205,   50000,      -- (Ammunition) Titanium Bolt Quiver
+        6206,   70000,      -- (Ammunition) Bismuth Bolt Quiver
+        6281,   90000,      -- (Ammunition) Ra'Kaznar Bolt Quiver
+        6310,   90000,      -- (Ammunition) Gashing Bolt Quiver
+        5823,   7500,       -- (Ammunition) Oberon's Bullet Pouch
+        6142,   11500,      -- (Ammunition) Midrium Bullet Pouch
+        6143,   35000,      -- (Ammunition) Damascus Bullet Pouch
+        6209,   50000,      -- (Ammunition) Titanium Bullet Pouch
+        6210,   70000,      -- (Ammunition) Bismuth Bullet Pouch
+        6282,   90000,      -- (Ammunition) Ra'Kaznar Bullet Pouch
+    }
+    
+    local playerLvl = player:getMainLvl() + player:getAverageItemLevel()
+    local t1Unlock = 0
+    local t2Unlock = 0
+    local t3Unlock = 0
+    local t4Unlock = 0
+    
+    if (player:getCharVar("KillCounter_Byakko") >= 1 and player:getCharVar("KillCounter_Genbu") >= 1 and
+        player:getCharVar("KillCounter_Seiryu") >= 1 and player:getCharVar("KillCounter_Suzaku") >= 1) then
+        t1Unlock = 1
+        -- printf("Vainrachault.lua onTrigger TIER 3 UNLOCKED  [%i]", t1Unlock)
+    end
+    
+    if (player:getCharVar("KillCounter_IxAernDRG") >= 1 and player:getCharVar("KillCounter_IxAernDRK") >= 1 and player:getCharVar("KillCounter_IxAernMNK") >= 1 and
+        player:getCharVar("KillCounter_JailOfFaith") >= 1 and player:getCharVar("KillCounter_JailOfFort") >= 1 and player:getCharVar("KillCounter_JailOfTemp") >= 1) then
+        t2Unlock = 1
+        -- printf("Vainrachault.lua onTrigger TIER 4 UNLOCKED")
+    end
+    
+    if (player:getCharVar("KillCounter_Kirin") >= 1 and player:getCharVar("KillCounter_JailOfLove") >= 1) then
+        t3Unlock = 1
+        -- printf("Vainrachault.lua onTrigger TIER 5 UNLOCKED")
+    end
+    
+    if (player:getCharVar("KillCounter_ShadowLord") >= 1 and player:getCharVar("KillCounter_Kamlanaut") >= 1) then
+        t4Unlock = 1
+        -- printf("Vainrachault.lua onTrigger TIER 6 UNLOCKED")
+    end
+    
+    if (playerLvl >= 99 and t1Unlock == 1 and t2Unlock == 1 and t3Unlock == 1 and t4Unlock == 1) then
+        xi.shop.general(player, stock_t4_locked)
+        -- printf("Vainrachault.lua onTrigger TIER 6 SHOP")
+    elseif (playerLvl >= 99 and t1Unlock == 1 and t2Unlock == 1 and t3Unlock == 1) then
+        xi.shop.general(player, stock_t3_locked)
+        -- printf("Vainrachault.lua onTrigger TIER 5 SHOP")
+    elseif (playerLvl >= 99 and t1Unlock == 1 and t2Unlock == 1) then
+        xi.shop.general(player, stock_t2_locked)
+        -- printf("Vainrachault.lua onTrigger TIER 4 SHOP")
+    elseif (playerLvl >= 99 and t1Unlock == 1) then
+        xi.shop.general(player, stock_t1_locked)
+        -- printf("Vainrachault.lua onTrigger TIER 3 SHOP")
+    elseif (playerLvl >= 99) then
+        xi.shop.general(player, stock_over_99_basic)
+        -- printf("Vainrachault.lua onTrigger TIER 2 SHOP")
+    else
+        xi.shop.general(player, stock_under_99)
+        -- printf("Vainrachault.lua onTrigger TIER 1 SHOP")
+    end
+    
+    player:PrintToPlayer(string.format("Vainrachault : Looking for ranged ammunition? I have a wide variety available for sale!"),xi.msg.channel.NS_SAY)
 end)
 
 return m

--- a/modules/custom/lua/caldera_npc_module/Vainrachault.lua
+++ b/modules/custom/lua/caldera_npc_module/Vainrachault.lua
@@ -1,0 +1,246 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Vainrachault
+-- !pos -111.187 -2.15 -85.478
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
+require("modules/module_utils")
+-----------------------------------
+
+local m = Module:new("Vainrachault")
+
+local npcToReplaceName = "Vainrachault"
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+	local stock_under_99 = 
+	{
+		5402, 7500,			-- (Ammunition) Fire Card Case
+		5403, 7500,			-- (Ammunition) Ice Card Case
+		5404, 7500,			-- (Ammunition) Wind Card Case
+		5405, 7500,			-- (Ammunition) Earth Card Case
+		5406, 7500,			-- (Ammunition) Thunder Card Case
+		5407, 7500,			-- (Ammunition) Water Card Case
+		5408, 7500,			-- (Ammunition) Light Card Case
+		5409, 7500,			-- (Ammunition) Dark Card Case
+		5870, 12500,		-- (Ammunition) Trump Card Case
+		17296,	1,			-- (Throwing) Pebble
+		17298,	20,			-- (Ammunition) Tathlum
+		17299,	50,			-- (Ammunition) Astragalos
+		17290,	5000,		-- (Throwing) Coarse Boomerang
+		6299,	500,		-- (Throwing) Shuriken Pouch
+		6297,	2000,		-- (Throwing) Juji Shuriken Pouch
+		6302,	5000,		-- (Throwing) Fuma Shuriken Pouch
+		6300,	7500,		-- (Throwing) Koga Shuriken Pouch
+		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
+		4219,	200,		-- (Ammunition) Stone Arrow Quiver
+		4222,	2000,		-- (Ammunition) Horn Arrow Quiver
+		4224,	5000,		-- (Ammunition) Demon Arrow Quiver
+		5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
+		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
+		4227,	200,		-- (Ammunition) Bronze Bolt Quiver
+		4228,	2000,		-- (Ammunition) Mythril Bolt Quiver
+		4229,	5000,		-- (Ammunition) Darksteel Bolt Quiver
+		5821,	7500,		-- (Ammunition) Fusion Bolt Quiver
+		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
+		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
+		5359,	200,		-- (Ammunition) Bronze Bullet Pouch
+		5363,	2000,		-- (Ammunition) Bullet Pouch
+		5353,	5000,		-- (Ammunition) Iron Bullet Pouch
+		17342,	75,			-- (Ammunition) Cannon Shell
+		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
+		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
+	}
+	
+	local stock_over_99_basic = 
+	{
+		5402, 7500,			-- (Ammunition) Fire Card Case
+		5403, 7500,			-- (Ammunition) Ice Card Case
+		5404, 7500,			-- (Ammunition) Wind Card Case
+		5405, 7500,			-- (Ammunition) Earth Card Case
+		5406, 7500,			-- (Ammunition) Thunder Card Case
+		5407, 7500,			-- (Ammunition) Water Card Case
+		5408, 7500,			-- (Ammunition) Light Card Case
+		5409, 7500,			-- (Ammunition) Dark Card Case
+		5870, 12500,		-- (Ammunition) Trump Card Case
+		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
+		5819,	7500,		-- (Ammunition) Antlion Arrow Quiver
+		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
+		6138,	35000,		-- (Ammunition) Mantid Arrow Quiver
+		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
+		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
+		6140,	35000,		-- (Ammunition) Damascus Bolt Quiver
+		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
+		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
+		6143,	35000,		-- (Ammunition) Damascus Bullet Pouch
+	}
+	
+	local stock_t1_locked = 
+	{
+		5402, 7500,			-- (Ammunition) Fire Card Case
+		5403, 7500,			-- (Ammunition) Ice Card Case
+		5404, 7500,			-- (Ammunition) Wind Card Case
+		5405, 7500,			-- (Ammunition) Earth Card Case
+		5406, 7500,			-- (Ammunition) Thunder Card Case
+		5407, 7500,			-- (Ammunition) Water Card Case
+		5408, 7500,			-- (Ammunition) Light Card Case
+		5409, 7500,			-- (Ammunition) Dark Card Case
+		5870, 12500,		-- (Ammunition) Trump Card Case
+		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
+		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
+		6138,	35000,		-- (Ammunition) Mantid Arrow Quiver
+		6201,	50000,		-- (Ammunition) Tulfaire Arrow Quiver
+		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
+		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
+		6140,	35000,		-- (Ammunition) Damascus Bolt Quiver
+		6205,	50000,		-- (Ammunition) Titanium Bolt Quiver
+		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
+		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
+		6143,	35000,		-- (Ammunition) Damascus Bullet Pouch
+		6209,	50000,		-- (Ammunition) Titanium Bullet Pouch
+	}
+	
+	local stock_t2_locked = 
+	{
+		5402, 7500,			-- (Ammunition) Fire Card Case
+		5403, 7500,			-- (Ammunition) Ice Card Case
+		5404, 7500,			-- (Ammunition) Wind Card Case
+		5405, 7500,			-- (Ammunition) Earth Card Case
+		5406, 7500,			-- (Ammunition) Thunder Card Case
+		5407, 7500,			-- (Ammunition) Water Card Case
+		5408, 7500,			-- (Ammunition) Light Card Case
+		5409, 7500,			-- (Ammunition) Dark Card Case
+		5870, 12500,		-- (Ammunition) Trump Card Case
+		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
+		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
+		6138,	35000,		-- (Ammunition) Mantid Arrow Quiver
+		6201,	50000,		-- (Ammunition) Tulfaire Arrow Quiver
+		6202,	70000,		-- (Ammunition) Raaz Arrow Quiver
+		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
+		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
+		6140,	35000,		-- (Ammunition) Damascus Bolt Quiver
+		6205,	50000,		-- (Ammunition) Titanium Bolt Quiver
+		6206,	70000,		-- (Ammunition) Bismuth Bolt Quiver
+		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
+		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
+		6143,	35000,		-- (Ammunition) Damascus Bullet Pouch
+		6209,	50000,		-- (Ammunition) Titanium Bullet Pouch
+		6210,	70000,		-- (Ammunition) Bismuth Bullet Pouch
+	}
+	
+	local stock_t3_locked = 
+	{
+		5402, 7500,			-- (Ammunition) Fire Card Case
+		5403, 7500,			-- (Ammunition) Ice Card Case
+		5404, 7500,			-- (Ammunition) Wind Card Case
+		5405, 7500,			-- (Ammunition) Earth Card Case
+		5406, 7500,			-- (Ammunition) Thunder Card Case
+		5407, 7500,			-- (Ammunition) Water Card Case
+		5408, 7500,			-- (Ammunition) Light Card Case
+		5409, 7500,			-- (Ammunition) Dark Card Case
+		5870, 12500,		-- (Ammunition) Trump Card Case
+		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
+		6308,	30000,		-- (Throwing) Hachiya Shuriken Pouch
+		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
+		6138,	35000,		-- (Ammunition) Mantid Arrow Quiver
+		6201,	50000,		-- (Ammunition) Tulfaire Arrow Quiver
+		6202,	70000,		-- (Ammunition) Raaz Arrow Quiver
+		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
+		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
+		6140,	35000,		-- (Ammunition) Damascus Bolt Quiver
+		6205,	50000,		-- (Ammunition) Titanium Bolt Quiver
+		6206,	70000,		-- (Ammunition) Bismuth Bolt Quiver
+		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
+		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
+		6143,	35000,		-- (Ammunition) Damascus Bullet Pouch
+		6209,	50000,		-- (Ammunition) Titanium Bullet Pouch
+		6210,	70000,		-- (Ammunition) Bismuth Bullet Pouch
+	}
+	
+	local stock_t4_locked = 
+	{
+		5402, 7500,			-- (Ammunition) Fire Card Case
+		5403, 7500,			-- (Ammunition) Ice Card Case
+		5404, 7500,			-- (Ammunition) Wind Card Case
+		5405, 7500,			-- (Ammunition) Earth Card Case
+		5406, 7500,			-- (Ammunition) Thunder Card Case
+		5407, 7500,			-- (Ammunition) Water Card Case
+		5408, 7500,			-- (Ammunition) Light Card Case
+		5409, 7500,			-- (Ammunition) Dark Card Case
+		5870, 12500,		-- (Ammunition) Trump Card Case
+		6304,	12000,		-- (Throwing) Roppo Shuriken Pouch
+		6308,	30000,		-- (Throwing) Hachiya Shuriken Pouch
+		6137,	11500,		-- (Ammunition) Chapuli Arrow Quiver
+		6138,	35000,		-- (Ammunition) Mantid Arrow Quiver
+		6201,	50000,		-- (Ammunition) Tulfaire Arrow Quiver
+		6202,	70000,		-- (Ammunition) Raaz Arrow Quiver
+		6280,	90000,		-- (Ammunition) Ra'Kaznar Arrow Quiver
+		6141,	11500,		-- (Ammunition) Oxidant Bolt Quiver
+		6139,	11500,		-- (Ammunition) Midrium Bolt Quiver
+		6140,	35000,		-- (Ammunition) Damascus Bolt Quiver
+		6205,	50000,		-- (Ammunition) Titanium Bolt Quiver
+		6206,	70000,		-- (Ammunition) Bismuth Bolt Quiver
+		6281,	90000,		-- (Ammunition) Ra'Kaznar Bolt Quiver
+		6310,	90000,		-- (Ammunition) Gashing Bolt Quiver
+		5823,	7500,		-- (Ammunition) Oberon's Bullet Pouch
+		6142,	11500,		-- (Ammunition) Midrium Bullet Pouch
+		6143,	35000,		-- (Ammunition) Damascus Bullet Pouch
+		6209,	50000,		-- (Ammunition) Titanium Bullet Pouch
+		6210,	70000,		-- (Ammunition) Bismuth Bullet Pouch
+		6282,	90000,		-- (Ammunition) Ra'Kaznar Bullet Pouch
+	}
+	
+	local playerLvl = player:getMainLvl() + player:getAverageItemLevel()
+	local t1Unlock = 0
+	local t2Unlock = 0
+	local t3Unlock = 0
+	local t4Unlock = 0
+	
+	if (player:getCharVar("KillCounter_Byakko") >= 1 and player:getCharVar("KillCounter_Genbu") >= 1 and
+		player:getCharVar("KillCounter_Seiryu") >= 1 and player:getCharVar("KillCounter_Suzaku") >= 1) then
+		t1Unlock = 1
+		-- printf("Vainrachault.lua onTrigger TIER 3 UNLOCKED  [%i]", t1Unlock)
+	end
+	
+	if (player:getCharVar("KillCounter_IxAernDRG") >= 1 and player:getCharVar("KillCounter_IxAernDRK") >= 1 and player:getCharVar("KillCounter_IxAernMNK") >= 1 and
+		player:getCharVar("KillCounter_JailOfFaith") >= 1 and player:getCharVar("KillCounter_JailOfFort") >= 1 and player:getCharVar("KillCounter_JailOfTemp") >= 1) then
+		t2Unlock = 1
+		-- printf("Vainrachault.lua onTrigger TIER 4 UNLOCKED")
+	end
+	
+	if (player:getCharVar("KillCounter_Kirin") >= 1 and player:getCharVar("KillCounter_JailOfLove") >= 1) then
+		t3Unlock = 1
+		-- printf("Vainrachault.lua onTrigger TIER 5 UNLOCKED")
+	end
+	
+	if (player:getCharVar("KillCounter_ShadowLord") >= 1 and player:getCharVar("KillCounter_Kamlanaut") >= 1) then
+		t4Unlock = 1
+		-- printf("Vainrachault.lua onTrigger TIER 6 UNLOCKED")
+	end
+	
+	if (playerLvl >= 99 and t1Unlock == 1 and t2Unlock == 1 and t3Unlock == 1 and t4Unlock == 1) then
+		xi.shop.general(player, stock_t4_locked)
+		-- printf("Vainrachault.lua onTrigger TIER 6 SHOP")
+	elseif (playerLvl >= 99 and t1Unlock == 1 and t2Unlock == 1 and t3Unlock == 1) then
+		xi.shop.general(player, stock_t3_locked)
+		-- printf("Vainrachault.lua onTrigger TIER 5 SHOP")
+	elseif (playerLvl >= 99 and t1Unlock == 1 and t2Unlock == 1) then
+		xi.shop.general(player, stock_t2_locked)
+		-- printf("Vainrachault.lua onTrigger TIER 4 SHOP")
+	elseif (playerLvl >= 99 and t1Unlock == 1) then
+		xi.shop.general(player, stock_t1_locked)
+		-- printf("Vainrachault.lua onTrigger TIER 3 SHOP")
+	elseif (playerLvl >= 99) then
+		xi.shop.general(player, stock_over_99_basic)
+		-- printf("Vainrachault.lua onTrigger TIER 2 SHOP")
+	else
+		xi.shop.general(player, stock_under_99)
+		-- printf("Vainrachault.lua onTrigger TIER 1 SHOP")
+	end
+	
+	player:PrintToPlayer(string.format("Vainrachault : Looking for ranged ammunition? I have a wide variety available for sale!"),xi.msg.channel.NS_SAY)
+end)
+
+return m

--- a/modules/custom/lua/caldera_npc_module/Yefafa.lua
+++ b/modules/custom/lua/caldera_npc_module/Yefafa.lua
@@ -14,12 +14,12 @@ local npcToReplaceName = "Yefafa"
 
 m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
     player:PrintToPlayer(string.format("Yefafa : You want me to act like a Moogle huh!? Well, ku-po-po-KUPOW!"),xi.msg.channel.NS_SAY)
-	player:dispelAllStatusEffect(bit.bor(xi.effectFlag.NONE, xi.effectFlag.DISPELABLE, xi.effectFlag.ERASABLE, xi.effectFlag.ATTACK,
-										 xi.effectFlag.EMPATHY, xi.effectFlag.DAMAGE, xi.effectFlag.MAGIC_BEGIN,
-										 xi.effectFlag.MAGIC_END, xi.effectFlag.ON_ZONE, xi.effectFlag.NO_LOSS_MESSAGE, xi.effectFlag.INVISIBLE,
-										 xi.effectFlag.DETECTABLE, xi.effectFlag.NO_REST, xi.effectFlag.PREVENT_ACTION, xi.effectFlag.WALTZABLE,
-										 xi.effectFlag.SONG, xi.effectFlag.ROLL, xi.effectFlag.CONFRONTATION, xi.effectFlag.LOGOUT,
-										 xi.effectFlag.BLOODPACT, xi.effectFlag.ON_JOBCHANGE, xi.effectFlag.OFFLINE_TICK, xi.effectFlag.AURA))
+    player:dispelAllStatusEffect(bit.bor(xi.effectFlag.NONE, xi.effectFlag.DISPELABLE, xi.effectFlag.ERASABLE, xi.effectFlag.ATTACK,
+                                         xi.effectFlag.EMPATHY, xi.effectFlag.DAMAGE, xi.effectFlag.MAGIC_BEGIN,
+                                         xi.effectFlag.MAGIC_END, xi.effectFlag.ON_ZONE, xi.effectFlag.NO_LOSS_MESSAGE, xi.effectFlag.INVISIBLE,
+                                         xi.effectFlag.DETECTABLE, xi.effectFlag.NO_REST, xi.effectFlag.PREVENT_ACTION, xi.effectFlag.WALTZABLE,
+                                         xi.effectFlag.SONG, xi.effectFlag.ROLL, xi.effectFlag.CONFRONTATION, xi.effectFlag.LOGOUT,
+                                         xi.effectFlag.BLOODPACT, xi.effectFlag.ON_JOBCHANGE, xi.effectFlag.OFFLINE_TICK, xi.effectFlag.AURA))
     player:sendMenu(1)
 end)
 

--- a/modules/custom/lua/caldera_npc_module/Yefafa.lua
+++ b/modules/custom/lua/caldera_npc_module/Yefafa.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Celennia Memorial Library
+--  NPC: Yefafa
+-- !pos -115.7428 -2.1500 -95.0393 284
+-----------------------------------
+local ID = require("scripts/zones/Celennia_Memorial_Library/IDs")
+require("modules/module_utils")
+-----------------------------------
+
+local m = Module:new("Yefafa")
+
+local npcToReplaceName = "Yefafa"
+
+
+m:addOverride(string.format("xi.zones.Celennia_Memorial_Library.npcs.%s.onTrigger", npcToReplaceName), function(player,npc)
+    player:PrintToPlayer(string.format("Yefafa : You want me to act like a Moogle huh!? Well, ku-po-po-KUPOW!"),xi.msg.channel.NS_SAY)
+	player:dispelAllStatusEffect(bit.bor(xi.effectFlag.NONE, xi.effectFlag.DISPELABLE, xi.effectFlag.ERASABLE, xi.effectFlag.ATTACK,
+										 xi.effectFlag.EMPATHY, xi.effectFlag.DAMAGE, xi.effectFlag.MAGIC_BEGIN,
+										 xi.effectFlag.MAGIC_END, xi.effectFlag.ON_ZONE, xi.effectFlag.NO_LOSS_MESSAGE, xi.effectFlag.INVISIBLE,
+										 xi.effectFlag.DETECTABLE, xi.effectFlag.NO_REST, xi.effectFlag.PREVENT_ACTION, xi.effectFlag.WALTZABLE,
+										 xi.effectFlag.SONG, xi.effectFlag.ROLL, xi.effectFlag.CONFRONTATION, xi.effectFlag.LOGOUT,
+										 xi.effectFlag.BLOODPACT, xi.effectFlag.ON_JOBCHANGE, xi.effectFlag.OFFLINE_TICK, xi.effectFlag.AURA))
+    player:sendMenu(1)
+end)
+
+return m

--- a/modules/init.txt
+++ b/modules/init.txt
@@ -36,6 +36,7 @@
 #
 # Live example:
 
+custom/lua/caldera_npc_module
 custom/commands/Caldera_commands
 custom/lua/test_npcs_in_gm_home.lua
 

--- a/scripts/zones/Celennia_Memorial_Library/DefaultActions.lua
+++ b/scripts/zones/Celennia_Memorial_Library/DefaultActions.lua
@@ -1,9 +1,3 @@
 local ID = require('scripts/zones/Celennia_Memorial_Library/IDs')
 
-return {
-    ['Andreine']     = { event = 27 },
-    ['Hestefa']      = { event = 23 },
-    ['Makel-Pakel']  = { event = 34 },
-    ['Trystol']      = { event = 25 },
-    ['Vainrachault'] = { event = 24 },
-}
+return {}

--- a/scripts/zones/Celennia_Memorial_Library/npcs/Andreine.lua
+++ b/scripts/zones/Celennia_Memorial_Library/npcs/Andreine.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Celennia Memorial Library (284)
+--  NPC: Andreine
+-- 
+-----------------------------------
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Celennia_Memorial_Library/npcs/Geography.lua
+++ b/scripts/zones/Celennia_Memorial_Library/npcs/Geography.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Celennia Memorial Library (284)
+--  NPC: Geography
+-- 
+-----------------------------------
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Celennia_Memorial_Library/npcs/Hestefa.lua
+++ b/scripts/zones/Celennia_Memorial_Library/npcs/Hestefa.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Celennia Memorial Library (284)
+--  NPC: Hestefa
+-- 
+-----------------------------------
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Celennia_Memorial_Library/npcs/Institutions.lua
+++ b/scripts/zones/Celennia_Memorial_Library/npcs/Institutions.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Celennia Memorial Library (284)
+--  NPC: Institutions
+-- 
+-----------------------------------
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Celennia_Memorial_Library/npcs/Jedelaih.lua
+++ b/scripts/zones/Celennia_Memorial_Library/npcs/Jedelaih.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Celennia Memorial Library (284)
+--  NPC: Jedelaih
+-- 
+-----------------------------------
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Celennia_Memorial_Library/npcs/Makel-Pakel.lua
+++ b/scripts/zones/Celennia_Memorial_Library/npcs/Makel-Pakel.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Celennia Memorial Library (284)
+--  NPC: Makel-Pakel
+-- 
+-----------------------------------
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Celennia_Memorial_Library/npcs/Personages.lua
+++ b/scripts/zones/Celennia_Memorial_Library/npcs/Personages.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Celennia Memorial Library (284)
+--  NPC: Personages
+-- 
+-----------------------------------
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Celennia_Memorial_Library/npcs/Reja_Ygridhi.lua
+++ b/scripts/zones/Celennia_Memorial_Library/npcs/Reja_Ygridhi.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Celennia Memorial Library (284)
+--  NPC: Reja Ygridhi
+-- 
+-----------------------------------
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Celennia_Memorial_Library/npcs/Trystol.lua
+++ b/scripts/zones/Celennia_Memorial_Library/npcs/Trystol.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Celennia Memorial Library (284)
+--  NPC: Trystol
+-- 
+-----------------------------------
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Celennia_Memorial_Library/npcs/Vainrachault.lua
+++ b/scripts/zones/Celennia_Memorial_Library/npcs/Vainrachault.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Celennia Memorial Library (284)
+--  NPC: Vainrachault
+-- 
+-----------------------------------
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

This creates a new set of module overrides to apply custom Caldera NPC code to Celennia Memorial Library Zone NPCs. Additionally this creates empty lua files for otherwise nonfunctional NPCs in the LSB Zone folder and also removes functions from DefaultActions.lua to allow for their dialogue to be bypassed.

## Steps to test these changes

1. Load in all PR changes into repository.
2. restart the map server and allow for modules to load and apply.
3. use the !library command to zone into the Celennia Memorial Library.
4. click on and trigger the various NPC shops and functions. 

https://www.ffxi-caldera.net/wiki/index.php/Library
