### PR TITLE
Add nullptr check and error message to CLuaZone

### DIFF
--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -184,7 +184,10 @@ WEATHER CLuaZone::getWeather()
 
 void CLuaZone::reloadNavmesh()
 {
-    m_pLuaZone->m_navMesh->reload();
+    if (m_pLuaZone->m_navMesh)
+    {
+        m_pLuaZone->m_navMesh->reload();
+    }
 }
 
 bool CLuaZone::isNavigablePoint(const sol::table& point)
@@ -200,7 +203,14 @@ bool CLuaZone::isNavigablePoint(const sol::table& point)
     };
     // clang-format on
 
-    return m_pLuaZone->m_navMesh->validPosition(position);
+    if (m_pLuaZone->m_navMesh)
+    {
+        return m_pLuaZone->m_navMesh->validPosition(position);
+    }
+    else // No navmesh, just nod and smile
+    {
+        return true;
+    }
 }
 
 std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Adds a nullptr check to navmeshes to ensure they do not cause crashes.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Zone into The Shrine of Ru'Avitau and confirm the server doesn't crash.